### PR TITLE
fix: use correct configURL for magika JS

### DIFF
--- a/js/magika.js
+++ b/js/magika.js
@@ -72,7 +72,7 @@ export class Magika {
    */
   async load({ modelURL, configURL }) {
     modelURL = modelURL || "https://google.github.io/magika/model/model.json";
-    configURL = configURL || "https://google.github.io/magika/model/model.json";
+    configURL = configURL || "https://google.github.io/magika/model/config.json";
     this.config = new Config();
     this.model = new Model();
     await Promise.all([this.config.load(configURL), this.model.load(modelURL)]);


### PR DESCRIPTION
The `modelURL` is also used as `configURL`
https://github.com/google/magika/blob/59c4cd76367020662e5148363aee2df1102acdc4/js/magika.js#L74-L75

This will cause a weird error to be thrown:

```error
Uncaught (in promise) RangeError: offset is out of bounds
    at Uint16Array.set (<anonymous>)
    at Magika._extractFeaturesFromBytes (magika.js:182:9)
    at Magika._identifyBytes (magika.js:143:53)
    at Magika.identifyBytes (magika.js:92:17)
    at fileReader.onload (index.tsx:141:40)
```