### PR TITLE
fix: initialise default load options in `Magika` class (npm/js)

### DIFF
--- a/js/magika.js
+++ b/js/magika.js
@@ -70,7 +70,7 @@ export class Magika {
    * Both parameters are optional. If not provided, the model will be loaded from Github.
    *
    */
-  async load({ modelURL, configURL }) {
+  async load({ modelURL, configURL } = {}) {
     modelURL = modelURL || "https://google.github.io/magika/model/model.json";
     configURL = configURL || "https://google.github.io/magika/model/config.json";
     this.config = new Config();


### PR DESCRIPTION
This fixes the following error when using `magika.load()`:

```error
TypeError: Cannot destructure property 'modelURL' of 'undefined' as it is undefined.
```

> The current workaround is to use `magika.load({})`, which does not seem intuitive, and is also not what's described in the documentation.
---
As a side note, I was thinking of creating a constructor method in the `Magika` class that will perform the `Magika.load` operation by default, passing in the load options into the constructor. What do you think?