### PR TITLE
Add Expected extensions output mode to Magika CLI

### DIFF
--- a/python/magika/cli/magika.py
+++ b/python/magika/cli/magika.py
@@ -86,6 +86,13 @@ Send any feedback to {CONTACT_EMAIL} or via GitHub issues.
     help="Compatibility mode: output is as close as possible to `file` and colors are disabled.",
 )
 @click.option(
+    "-e",
+    "--expected-exts",
+    "expected_extensions",
+    is_flag=True,
+    help="Output the expected file extension(s), in case the input extension is missing or incorrect.",
+)
+@click.option(
     "-s",
     "--output-score",
     is_flag=True,
@@ -145,6 +152,7 @@ def main(
     mime_output: bool,
     label_output: bool,
     magic_compatibility_mode: bool,
+    expected_extensions:bool,
     output_score: bool,
     prediction_mode_str: str,
     batch_size: int,
@@ -217,8 +225,8 @@ def main(
         _l.error("You should use either --json or --jsonl, not both.")
         sys.exit(1)
 
-    if int(mime_output) + int(label_output) + int(magic_compatibility_mode) > 1:
-        _l.error("You should use only one of --mime, --label, --compatibility-mode.")
+    if int(mime_output) + int(label_output) + int(magic_compatibility_mode) + int(expected_extensions) > 1:
+        _l.error("You should use only one of --mime, --label, --compatibility-mode, --expected-exts.")
         sys.exit(1)
 
     if recursive:
@@ -312,6 +320,8 @@ def main(
                     output = magika_result.output.mime_type
                 elif label_output:
                     output = magika_result.output.ct_label
+                elif expected_extensions:
+                    output = magika_result.output.expected_exts
                 elif magic_compatibility_mode:
                     output = magika_result.output.magic
                 else:  # human-readable description

--- a/python/magika/content_types.py
+++ b/python/magika/content_types.py
@@ -242,7 +242,15 @@ class ContentTypesManager:
         if ct.mime_type is None:
             return default
         return ct.mime_type
-
+    
+    def get_exts(self, content_type_name:str , default:str = "") -> str:
+        ct = self.get(content_type_name)
+        if ct is None:
+            return default
+        if ct.extensions is None:
+            return default
+        return ",".join(ct.extensions)
+    
     def get_group(
         self,
         content_type_name: str,

--- a/python/magika/magika.py
+++ b/python/magika/magika.py
@@ -509,6 +509,8 @@ class Magika:
         )
         output_description = self._ctm.get_description(output_ct_label)
 
+        expected_exts = self._ctm.get_exts(output_ct_label)
+
         magika_result = MagikaResult(
             path=str(path),
             dl=ModelOutputFields(
@@ -526,6 +528,7 @@ class Magika:
                 mime_type=output_mime_type,
                 magic=output_magic,
                 description=output_description,
+                expected_exts = expected_exts
             ),
         )
 

--- a/python/magika/types.py
+++ b/python/magika/types.py
@@ -57,6 +57,8 @@ class MagikaOutputFields:
     mime_type: str
     magic: str
     description: str
+    expected_exts: Optional[str]
+
 
 
 @dataclass


### PR DESCRIPTION
Add `-e / --expected-exts` mode to Magika CLI, which output one or several expected file extensions of input file, in case the input extension is missed or incorrect