### PR TITLE
feat: initialise and load class in 1 call (npm/js)

### DIFF
--- a/js/magika.js
+++ b/js/magika.js
@@ -78,6 +78,12 @@ export class Magika {
     await Promise.all([this.config.load(configURL), this.model.load(modelURL)]);
   }
 
+  static async create(options = {}) {
+    const magika = new Magika();
+    await magika.load(options);
+    return magika;
+  }
+
   /** Identifies the content type of a byte stream.
    *
    * @param {*} fileBytes  a Buffer object (a fixed-length sequence of bytes)


### PR DESCRIPTION
Continuation of #52 

It is discouraged from using async functions in constructor methods in JavaScript. Instead, I implemented an alternative way to initialise the `Magika` class in 1 call.

Now there are 2 ways (both will achieve the same results). This way, we have a more efficient way to initialise the class, but we also preserve the original way for backwards compatibility.
```js
const magika = new Magika();
await magika.load();
```

or

```js
const magika = await Magika.create();
```

Both `load` and `create` function take in an optional parameter with a default parameter.