### PR TITLE
Explicitly set the providers with InferenceSession

### DIFF
--- a/python/magika/magika.py
+++ b/python/magika/magika.py
@@ -151,7 +151,7 @@ class Magika:
 
     def _init_onnx_session(self) -> rt.InferenceSession:
         start_time = time.time()
-        onnx_session = rt.InferenceSession(self._model_path)
+        onnx_session = rt.InferenceSession(self._model_path, providers=['AzureExecutionProvider', 'CPUExecutionProvider'])
         elapsed_time = time.time() - start_time
         self._log.debug(
             f'ONNX DL model "{self._model_path}" loaded in {elapsed_time:.03f} seconds'


### PR DESCRIPTION
Minor issue when running the code. ORT 1.9 requires setting the providers parameter when using InferenceSession.

`ValueError: This ORT build has ['AzureExecutionProvider', 'CPUExecutionProvider'] enabled. Since ORT 1.9, you are required to explicitly set the providers parameter when instantiating InferenceSession. For example, onnxruntime.InferenceSession(..., providers=['AzureExecutionProvider', 'CPUExecutionProvider'], ...)`

I resolved the ValueError by explicitly adding the providers parameter in the `_init_onnx_session(self)` method.