### PR TITLE
Set pebin target_label in content_types_config.json

### DIFF
--- a/python/magika/config/content_types_config.json
+++ b/python/magika/config/content_types_config.json
@@ -2950,7 +2950,7 @@
         "parent": null,
         "tags": [],
         "model_target_label": null,
-        "target_label": null,
+        "target_label": "pebin",
         "correct_labels": [],
         "in_scope_for_output_content_type": true,
         "in_scope_for_training": false


### PR DESCRIPTION
FONNX is an open source Flutter library for running ONNX models cross-platform.

It has tests mirroring the sample files in google/magika.

I added code to parse content_types_config.json into a Dart enum. 

Two tests failed after switching to this new model code: mitra/pe32.exe and mitra/pe64.exe.

Investigation revealed that was because there was no target_label set for pebin, so the new model code was using `null`. 

This seems to be an error, since the model does output pebin results.