### PR TITLE
Add e2e testing of Python package using GitHub Actions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,4 +1,4 @@
-name: E2E Testing
+name: Python
 on:
     push:
       branches:
@@ -37,7 +37,7 @@ jobs:
 
       - name: List wheels
         working-directory: python
-        run: ls -la python/dist
+        run: ls -la dist/
 
       - name: Install magika
         working-directory: python

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8.x", "3.9.x", "3.10.x", "3.11.x", "3.12.x"]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +34,10 @@ jobs:
       - name: Install the project dependencies
         working-directory: python
         run: poetry build
+
+      - name: List wheels
+        working-directory: python
+        run: ls -la dist/
 
       - name: Install magika
         working-directory: python

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -35,10 +35,6 @@ jobs:
         working-directory: python
         run: poetry build
 
-      - name: List wheels
-        working-directory: python
-        run: ls -la dist/
-
       - name: Install magika
         working-directory: python
         run: pip install dist/magika-*.whl

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,7 +2,7 @@ name: Python
 on:
     push:
       branches:
-        - '**'
+        - 'main'
       paths:
         - 'python/**'
         - '.github/workflows/**'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8.x", "3.9.x", "3.10.x", "3.11.x", "3.12.x"]
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,13 +1,15 @@
-name: E2E Test
+name: E2E Testing
 on:
     push:
       branches:
         - '**'
       paths:
         - 'python/**'
+        - '.github/workflows/**'
     pull_request:
       paths:
         - 'python/**'
+        - '.github/workflows/**'
 
 jobs:
   e2e-testing:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8.x", "3.9.x", "3.10.x", "3.11.x", "3.12.x"]
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,11 +37,12 @@ jobs:
 
       - name: List wheels
         working-directory: python
-        run: ls -la dist/
+        run: python -c "import os; print('\n'.join(os.listdir('dist')))"
 
       - name: Install magika
         working-directory: python
-        run: pip install dist/magika-*.whl
+        run: python -m pip install $(python -c "import glob; print(glob.glob('dist/magika-*.whl')[0])")
+        shell: bash # Allows for cross-platform
 
       - name: Run magika with tests_data
         run: magika -r tests_data/ || exit 1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -44,4 +44,4 @@ jobs:
         run: pip install dist/magika-*.whl
 
       - name: Run magika with tests_data
-        run: magika -r tests_data/
+        run: magika -r tests_data/ || exit 1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,4 +1,4 @@
-name: E2E Testing
+name: E2E Test
 on:
     push:
       branches:

--- a/.github/workflows/pkg-test.yml
+++ b/.github/workflows/pkg-test.yml
@@ -1,0 +1,45 @@
+name: E2E Testing
+on:
+    push:
+      branches:
+        - '**'
+      paths:
+        - 'python/**'
+    pull_request:
+      paths:
+        - 'python/**'
+
+jobs:
+  e2e-testing:
+    strategy:
+      matrix:
+        python-version: ["3.8.x", "3.9.x", "3.10.x", "3.11.x", "3.12.x"]
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python-version }}'
+
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: "1.7.1"
+
+      - name: Install the project dependencies
+        working-directory: python
+        run: poetry build
+
+      - name: List wheels
+        working-directory: python
+        run: ls -la python/dist
+
+      - name: Install magika
+        working-directory: python
+        run: pip install dist/magika-*.whl
+
+      - name: Run magika with tests_data
+        run: magika -r tests_data/


### PR DESCRIPTION
Automates the process of building `magika` python wheel, installing the wheel and running `magika` against the files in `tests_data/`. If unable it will fail the CI job.

The test is run against py38 -> py3.12 using both Linux, MacOS, and Windows.

![image](https://github.com/google/magika/assets/835733/9dea8822-23d4-406a-af84-11c45a945831)

Fixes #158 