### PR TITLE
Make examples more clear

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_content_type_request.md
+++ b/.github/ISSUE_TEMPLATE/new_content_type_request.md
@@ -8,6 +8,7 @@ assignees: ''
 ---
 
 **What type of file would you like magika to detect?**
+Write the full name of the file format, followed by the file extention in parenthacies.
 Examples:
  - "Nintendo Binary Revolution RESource (.brres)"
  - "Valve Map Format file (.vmf)"
@@ -18,32 +19,47 @@ Examples:
 
 **What software can create/open these files?**
 Examples:
- - "[BrawlCrate](https://github.com/soopercool101/BrawlCrate)"
- - "Valve Hammer Editor, included with any Source Engine game on Steam."
- - "[Blender](https://www.blender.org/download/)"
- - "[RPG Maker 2003](https://www.rpgmakerweb.com/products/rpg-maker-2003), [easyRPG](https://easyrpg.org/), Wolf RPG Editor"
- - "Many 3D modeling softwares."
- - "[Unreal Engine](https://www.unrealengine.com/en-US)"
- - "Any text editor."
+- Simply state the name of the software, and where it can be obtained.
+  - "Valve Hammer Editor, included with any Source Engine game on Steam."
+- If the file is common enough, write a general description.
+  - "Many 3D modeling softwares."
+  - "Any text editor."
+- Link to the GitHub page.
+  - "[BrawlCrate](https://github.com/soopercool101/BrawlCrate)"
+- Link to the software's websight main page or download page.
+  - "[Blender](https://www.blender.org/download/)"
+  - "[Unreal Engine](https://www.unrealengine.com/en-US)"
+- If there are more than one software to open the file type, list them.
+  - "[RPG Maker 2003](https://www.rpgmakerweb.com/products/rpg-maker-2003), [easyRPG](https://easyrpg.org/), Wolf RPG Editor"
+
 
 **Where can these files be found?**
 Examples:
- - "Dump the ISO of any of [these Wii games](https://wiki.vg-resource.com/BRRES#List_of_games_using_the_format)"
- - "Use [bspsrc](https://github.com/ata4/bspsrc) to decompile the BSP files of any Source Engine game. Use [GCFScape](https://nemstools.github.io/pages/GCFScape-Download.html) to extract even more BSPs from 'dir.vpk' files. Make your own with Hammer."
- - "https://blendermarket.com/categories/models, https://www.turbosquid.com/Search/3D-Models/marketplace/blend, https://sketchfab.com/store/3d-models/blend?ref=store-home"
- - "Any RPGMaker 2000/2003 game."
- - "[Unreal Marketplace](https://www.unrealengine.com/marketplace/en-US/store)"
- - "placeholder.zip"
+- Simply state where the files can be obtained.
+  - "Any RPGMaker 2000/2003 game."
+- Provide instructions on how to obtain the files.
+  - "Dump the ISO of any of [these Wii games](https://wiki.vg-resource.com/BRRES#List_of_games_using_the_format)"
+  - "Use [bspsrc](https://github.com/ata4/bspsrc) to decompile the BSP files of any Source Engine game. Use [GCFScape](https://nemstools.github.io/pages/GCFScape-Download.html) to extract even more BSPs from 'dir.vpk' files. Make your own with Hammer."
+ - link to a source of the files.
+   - "[Unreal Marketplace](https://www.unrealengine.com/marketplace/en-US/store)"
+   - "https://blendermarket.com/categories/models, https://www.turbosquid.com/Search/3D-Models/marketplace/blend, https://sketchfab.com/store/3d-models/blend?ref=store-home"
+ - provide some of your own.
+   - "placeholder.zip"
 
 **If possible, please provide a specification for this file type.**
+Link to a recource that explanes how the file works.
 Examples:
- - "https://wiki.tockdom.com/wiki/BRRES_(File_Format), https://horizon.miraheze.org/wiki/.brres"
- - "https://developer.valvesoftware.com/wiki/VMF_(Valve_Map_Format)"
- - "https://www.collada.org/2008/03/COLLADASchema"
- - "https://gota7.github.io/NitroStudio2/specs/sequenceArchive.html"
- - "http://www.amnoid.de/gc/Rarc.txt, https://kuribo64.net/wiki/?page=RARC, https://wiki.tockdom.com/wiki/RARC_(File_Format)"
- - "https://www.3dbrew.org/wiki/CGFX, https://mk3ds.com/index.php?title=CGFX_(File_Format)"
- - "https://mk8.tockdom.com/wiki/BFRES_(File_Format), https://wiki.vg-resource.com/BFRES, https://wiki.oatmealdome.me/BFRES_(File_Format)"
+- A wiki page.
+  - "https://developer.valvesoftware.com/wiki/VMF_(Valve_Map_Format)"
+- GitHub documentation.
+  - "https://gota7.github.io/NitroStudio2/specs/sequenceArchive.html"
+- If you find more than one source, list them.
+  - "https://wiki.tockdom.com/wiki/BRRES_(File_Format), https://horizon.miraheze.org/wiki/.brres"
+  - "http://www.amnoid.de/gc/Rarc.txt, https://kuribo64.net/wiki/?page=RARC, https://wiki.tockdom.com/wiki/RARC_(File_Format)"
+  - "https://www.3dbrew.org/wiki/CGFX, https://mk3ds.com/index.php?title=CGFX_(File_Format)"
+  - "https://mk8.tockdom.com/wiki/BFRES_(File_Format), https://wiki.vg-resource.com/BFRES, https://wiki.oatmealdome.me/BFRES_(File_Format)"
+- A PDF
+  - "https://www.collada.org/2008/03/COLLADASchema"
  
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/new_content_type_request.md
+++ b/.github/ISSUE_TEMPLATE/new_content_type_request.md
@@ -19,46 +19,46 @@ Examples:
 
 **What software can create/open these files?**
 Examples:
-- Simply state the name of the software, and where it can be obtained.
+- Simply state the name of the software, and where it can be obtained:
   - "Valve Hammer Editor, included with any Source Engine game on Steam."
-- If the file is common enough, write a general description.
+- If the file is common enough, write a general description:
   - "Many 3D modeling softwares."
   - "Any text editor."
-- Link to the GitHub page.
+- Link to the GitHub page:
   - "[BrawlCrate](https://github.com/soopercool101/BrawlCrate)"
-- Link to the software's websight main page or download page.
+- Link to the software's websight main page or download page:
   - "[Blender](https://www.blender.org/download/)"
   - "[Unreal Engine](https://www.unrealengine.com/en-US)"
-- If there are more than one software to open the file type, list them.
+- If there are more than one software to open the file type, list them:
   - "[RPG Maker 2003](https://www.rpgmakerweb.com/products/rpg-maker-2003), [easyRPG](https://easyrpg.org/), Wolf RPG Editor"
 
 
 **Where can these files be found?**
 Examples:
-- Simply state where the files can be obtained.
+- Simply state where the files can be obtained:
   - "Any RPGMaker 2000/2003 game."
-- Provide instructions on how to obtain the files.
+- Provide instructions on how to obtain the files:
   - "Dump the ISO of any of [these Wii games](https://wiki.vg-resource.com/BRRES#List_of_games_using_the_format)"
   - "Use [bspsrc](https://github.com/ata4/bspsrc) to decompile the BSP files of any Source Engine game. Use [GCFScape](https://nemstools.github.io/pages/GCFScape-Download.html) to extract even more BSPs from 'dir.vpk' files. Make your own with Hammer."
- - link to a source of the files.
+ - Link to a source of the files:
    - "[Unreal Marketplace](https://www.unrealengine.com/marketplace/en-US/store)"
    - "https://blendermarket.com/categories/models, https://www.turbosquid.com/Search/3D-Models/marketplace/blend, https://sketchfab.com/store/3d-models/blend?ref=store-home"
- - provide some of your own.
-   - "placeholder.zip"
+ - Provide some of your own:
+   - "placeholder.zip" as attachment.
 
 **If possible, please provide a specification for this file type.**
 Link to a recource that explanes how the file works.
 Examples:
-- A wiki page.
+- A wiki page:
   - "https://developer.valvesoftware.com/wiki/VMF_(Valve_Map_Format)"
-- GitHub documentation.
+- GitHub documentation:
   - "https://gota7.github.io/NitroStudio2/specs/sequenceArchive.html"
-- If you find more than one source, list them.
+- If you find more than one source, list them:
   - "https://wiki.tockdom.com/wiki/BRRES_(File_Format), https://horizon.miraheze.org/wiki/.brres"
   - "http://www.amnoid.de/gc/Rarc.txt, https://kuribo64.net/wiki/?page=RARC, https://wiki.tockdom.com/wiki/RARC_(File_Format)"
   - "https://www.3dbrew.org/wiki/CGFX, https://mk3ds.com/index.php?title=CGFX_(File_Format)"
   - "https://mk8.tockdom.com/wiki/BFRES_(File_Format), https://wiki.vg-resource.com/BFRES, https://wiki.oatmealdome.me/BFRES_(File_Format)"
-- A PDF
+- A PDF:
   - "https://www.collada.org/2008/03/COLLADASchema"
  
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/new_content_type_request.md
+++ b/.github/ISSUE_TEMPLATE/new_content_type_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **What type of file would you like magika to detect?**
-Write the full name of the file format, followed by the file extention in parenthacies.
+Write the full name of the file format, followed by the file extention in parenthesis.
 Examples:
  - "Nintendo Binary Revolution RESource (.brres)"
  - "Valve Map Format file (.vmf)"

--- a/docs/js.md
+++ b/docs/js.md
@@ -206,26 +206,26 @@ Returns **[Promise][21]\<ModelResult>** A dictionary containing the top label an
 
 [18]: #parameters-7
 
-[19]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L29-L134 "Source code on GitHub"
+[19]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L29-L134 "Source code on GitHub"
 
-[20]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L45-L58 "Source code on GitHub"
+[20]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L45-L58 "Source code on GitHub"
 
 [21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[22]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L66-L69 "Source code on GitHub"
+[22]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L66-L69 "Source code on GitHub"
 
 [23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[24]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L77-L80 "Source code on GitHub"
+[24]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L77-L80 "Source code on GitHub"
 
-[25]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L87-L91 "Source code on GitHub"
+[25]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L87-L91 "Source code on GitHub"
 
-[26]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L98-L101 "Source code on GitHub"
+[26]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L98-L101 "Source code on GitHub"
 
-[27]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L27-L123 "Source code on GitHub"
+[27]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L27-L123 "Source code on GitHub"
 
-[28]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L52-L57 "Source code on GitHub"
+[28]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L52-L57 "Source code on GitHub"
 
-[29]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L64-L67 "Source code on GitHub"
+[29]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L64-L67 "Source code on GitHub"
 
-[30]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L74-L77 "Source code on GitHub"
+[30]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L74-L77 "Source code on GitHub"

--- a/docs/js.md
+++ b/docs/js.md
@@ -206,26 +206,26 @@ Returns **[Promise][21]\<ModelResult>** A dictionary containing the top label an
 
 [18]: #parameters-7
 
-[19]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L29-L134 "Source code on GitHub"
+[19]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L29-L134 "Source code on GitHub"
 
-[20]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L45-L58 "Source code on GitHub"
+[20]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L45-L58 "Source code on GitHub"
 
 [21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[22]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L66-L69 "Source code on GitHub"
+[22]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L66-L69 "Source code on GitHub"
 
 [23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[24]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L77-L80 "Source code on GitHub"
+[24]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L77-L80 "Source code on GitHub"
 
-[25]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L87-L91 "Source code on GitHub"
+[25]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L87-L91 "Source code on GitHub"
 
-[26]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L98-L101 "Source code on GitHub"
+[26]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika_node.ts#L98-L101 "Source code on GitHub"
 
-[27]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L27-L123 "Source code on GitHub"
+[27]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L27-L123 "Source code on GitHub"
 
-[28]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L52-L57 "Source code on GitHub"
+[28]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L52-L57 "Source code on GitHub"
 
-[29]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L64-L67 "Source code on GitHub"
+[29]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L64-L67 "Source code on GitHub"
 
-[30]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L74-L77 "Source code on GitHub"
+[30]: https://github.com/google/magika/blob/48d4394825d19221b6413203469a549b15a841ae/js/magika.ts#L74-L77 "Source code on GitHub"

--- a/docs/js.md
+++ b/docs/js.md
@@ -206,26 +206,26 @@ Returns **[Promise][21]\<ModelResult>** A dictionary containing the top label an
 
 [18]: #parameters-7
 
-[19]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L29-L134 "Source code on GitHub"
+[19]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L29-L134 "Source code on GitHub"
 
-[20]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L45-L58 "Source code on GitHub"
+[20]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L45-L58 "Source code on GitHub"
 
 [21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
-[22]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L66-L69 "Source code on GitHub"
+[22]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L66-L69 "Source code on GitHub"
 
 [23]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[24]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L77-L80 "Source code on GitHub"
+[24]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L77-L80 "Source code on GitHub"
 
-[25]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L87-L91 "Source code on GitHub"
+[25]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L87-L91 "Source code on GitHub"
 
-[26]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L98-L101 "Source code on GitHub"
+[26]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika_node.ts#L98-L101 "Source code on GitHub"
 
-[27]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L27-L123 "Source code on GitHub"
+[27]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L27-L123 "Source code on GitHub"
 
-[28]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L52-L57 "Source code on GitHub"
+[28]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L52-L57 "Source code on GitHub"
 
-[29]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L64-L67 "Source code on GitHub"
+[29]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L64-L67 "Source code on GitHub"
 
-[30]: https://github.com/MichaelHinrichs/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L74-L77 "Source code on GitHub"
+[30]: https://github.com/google/magika/blob/ce2e897198693c9c07c5e0ae72ea2a5a4d03d96e/js/magika.ts#L74-L77 "Source code on GitHub"


### PR DESCRIPTION
I've seen some [NEW CONTENT TYPE REQUEST] issues that misunderstand the template. People think that the bullet points are part of one big example of a list. They are intended as a list of individual examples. I thought that the quotation marks, and entire comma separated lists under one bullet point made that clear when I wrote it. You don't need to use bullet points for one item, or keep the word "Examples", like [this](https://github.com/google/magika/issues/291), or [this](https://github.com/google/magika/issues/269), or [this](https://github.com/google/magika/issues/240), or [this](https://github.com/google/magika/issues/230), or [this](https://github.com/google/magika/issues/229), or [this](https://github.com/google/magika/issues/228), or, [this](https://github.com/google/magika/issues/227), or [this](https://github.com/google/magika/issues/218), or, [this](https://github.com/google/magika/issues/219), or [this](https://github.com/google/magika/issues/120), or [this](https://github.com/google/magika/issues/106), or [this](https://github.com/google/magika/issues/83), or [this](https://github.com/google/magika/issues/240).