### PR TITLE
Implement get_result_of_few_bytes in Rust

### DIFF
--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt::Write;
-use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -21,6 +20,7 @@ use anyhow::{bail, ensure, Result};
 use clap::Parser;
 use ort::GraphOptimizationLevel;
 use tokio::fs::File;
+use tokio::io::AsyncReadExt;
 
 /// Determines the content type of files with deep-learning.
 #[derive(Parser)]
@@ -133,7 +133,7 @@ async fn extract_features(
     for (index, path) in flags.path.iter().enumerate() {
         let features_or_output: magika::FeaturesOrOutput = if path.to_str() == Some("-") {
             let mut stdin = Vec::new();
-            std::io::stdin().read_to_end(&mut stdin)?;
+            tokio::io::stdin().read_to_end(&mut stdin).await?;
             magika::FeaturesOrOutput::extract_sync(&stdin[..])?
         } else {
             let mut result = None;

--- a/rust/lib/src/input.rs
+++ b/rust/lib/src/input.rs
@@ -117,13 +117,17 @@ impl AsyncInputApi for tokio::fs::File {
 
 impl FeaturesOrOutput {
     /// Extracts the features from a file (synchronously).
+    ///
+    /// Returns the output directly if the file is not suited for deep learning.
     pub fn extract_sync(file: impl SyncInput) -> Result<Self> {
-        extract_features_or_label_sync(BUFFER_SIZE, file)
+        extract_features_or_output_sync(BUFFER_SIZE, file)
     }
 
     /// Extracts the features from a file (asynchronously).
+    ///
+    /// Returns the output directly if the file is not suited for deep learning.
     pub async fn extract_async(file: impl AsyncInput) -> Result<Self> {
-        extract_features_or_label_async(BUFFER_SIZE, file).await
+        extract_features_or_output_async(BUFFER_SIZE, file).await
     }
 }
 
@@ -132,13 +136,13 @@ const FEATURE_PADDING: f32 = 256f32;
 const BUFFER_SIZE: usize = 8192;
 const MIN_SIZE_FOR_FEATURES: usize = 16;
 
-fn extract_features_or_label_sync(
+fn extract_features_or_output_sync(
     buffer_size: usize, file: impl SyncInputApi,
 ) -> Result<FeaturesOrOutput> {
-    crate::future::exec(extract_features_or_label_async(buffer_size, file))
+    crate::future::exec(extract_features_or_output_async(buffer_size, file))
 }
 
-async fn extract_features_or_label_async(
+async fn extract_features_or_output_async(
     buffer_size: usize, file: impl AsyncInputApi,
 ) -> Result<FeaturesOrOutput> {
     let (mut content, features) = extract_features_async(buffer_size, file).await?;

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -21,8 +21,7 @@
 //!
 //! # fn main() -> magika::Result<()> {
 //! let magika = Session::new()?;
-//! let features = Features::extract_sync(&b"#!/bin/sh\necho hello"[..])?;
-//! let result = magika.identify_one_sync(&features)?;
+//! let result = magika.identify_sync(&b"#!/bin/sh\necho hello"[..])?;
 //! assert_eq!(result.label(), Label::Shell);
 //! # Ok(())
 //! # }
@@ -32,7 +31,7 @@
 
 pub use crate::builder::Builder;
 pub use crate::error::{Error, Result};
-pub use crate::input::{AsyncInput, Features, SyncInput};
+pub use crate::input::{AsyncInput, Features, FeaturesOrOutput, SyncInput};
 pub use crate::label::Label;
 pub use crate::output::Output;
 pub use crate::session::Session;


### PR DESCRIPTION
This should address https://github.com/google/magika/issues/93#issuecomment-2137550297.

Changes in this PR:
- [lib] Add a `FeaturesOrOutput` type for the result of features extraction, which may now directly produce an output.
- [lib] Add two helpers to identify a file directly from its input without having to compute features first.
- [cli] Support reading from standard input.
