### PR TITLE
Implement same colored output in Rust CLI as Python

### DIFF
--- a/rust/cli/Cargo.lock
+++ b/rust/cli/Cargo.lock
@@ -197,6 +197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +443,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "clap",
+ "colored",
  "magika",
  "ort",
  "tokio",

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow = "1.0.82"
 async-channel = "2.2.0"
 clap = { version = "4.5.1", features = ["derive"] }
+colored = "2.1.0"
 magika = { version = "0.1.0-dev", path = "../lib", features = ["tokio"] }
 ort = "2.0.0-rc.1"
 tokio = { version = "1.37.0", features = ["full"] }


### PR DESCRIPTION
In particular, show the group instead of the score by default.