### PR TITLE
Disable automatic doc generation 

### DIFF
--- a/.github/workflows/js-docs-builder.yml
+++ b/.github/workflows/js-docs-builder.yml
@@ -2,6 +2,7 @@ name: JS - generate docs
 
 on:
   push:
+    # Runs on pushes targeting the default branch
     branches: [ "main" ]
     paths:
       - 'js/**'

--- a/.github/workflows/js-docs-builder.yml
+++ b/.github/workflows/js-docs-builder.yml
@@ -1,8 +1,8 @@
 name: JS - generate docs
 
 on:
+  # Runs on pushes targeting the default branch
   push:
-    # Runs on pushes targeting the default branch
     branches: [ "main" ]
     paths:
       - 'js/**'

--- a/.github/workflows/js-docs-builder.yml
+++ b/.github/workflows/js-docs-builder.yml
@@ -2,7 +2,7 @@ name: JS - generate docs
 
 on:
   push:
-    branches: [ ]
+    branches: [ "main" ]
     paths:
       - 'js/**'
       - '.github/workflows/**'
@@ -37,4 +37,3 @@ jobs:
           git config --local user.email "invernizzi.l@gmail.com"
           git config --local user.name "Luca Invernizzi"
           git commit -m "Update docs" -a
-          git push

--- a/.github/workflows/js-docs-builder.yml
+++ b/.github/workflows/js-docs-builder.yml
@@ -1,9 +1,8 @@
 name: JS - generate docs
 
 on:
-  # Runs on pushes targeting the default branch
   push:
-    branches: [ "main" ]
+    branches: [ ]
     paths:
       - 'js/**'
       - '.github/workflows/**'


### PR DESCRIPTION
Automatic doc generation for `/js` works, but the commit to the main branch fails because of branch protection. Disable that feature for now.