### PR TITLE
Update Rust tests to also run on previous_missdetections

### DIFF
--- a/rust/cli/output
+++ b/rust/cli/output
@@ -1,108 +1,108 @@
-+ magika test.sh
-test.sh: Shell script (code)
-+ magika test.sh --colors
-[1;34mtest.sh: Shell script (code)[0m
-+ magika test.sh --output-score
-test.sh: Shell script (code) 99%
-+ magika test.sh --json
++ magika rust/code.rs
+rust/code.rs: Rust source (code)
++ magika rust/code.rs --colors
+[1;34mrust/code.rs: Rust source (code)[0m
++ magika rust/code.rs --output-score
+rust/code.rs: Rust source (code) 89%
++ magika rust/code.rs --json
 [
   {
-    "path": "test.sh",
+    "path": "rust/code.rs",
     "result": {
       "status": "ok",
       "value": {
         "dl": {
-          "description": "Shell script",
+          "description": "Rust source",
           "extensions": [
-            "sh"
+            "rs"
           ],
           "group": "code",
           "is_text": true,
-          "label": "shell",
-          "mime_type": "text/x-shellscript"
+          "label": "rust",
+          "mime_type": "application/x-rust"
         },
         "output": {
-          "description": "Shell script",
+          "description": "Rust source",
           "extensions": [
-            "sh"
+            "rs"
           ],
           "group": "code",
           "is_text": true,
-          "label": "shell",
-          "mime_type": "text/x-shellscript"
+          "label": "rust",
+          "mime_type": "application/x-rust"
         },
-        "score": 0.9980000257492065
+        "score": 0.8949999809265137
       }
     }
   }
 ]
-+ magika test.sh README.md --json
++ magika rust/code.rs python/code.py --json
 [
   {
-    "path": "test.sh",
+    "path": "rust/code.rs",
     "result": {
       "status": "ok",
       "value": {
         "dl": {
-          "description": "Shell script",
+          "description": "Rust source",
           "extensions": [
-            "sh"
+            "rs"
           ],
           "group": "code",
           "is_text": true,
-          "label": "shell",
-          "mime_type": "text/x-shellscript"
+          "label": "rust",
+          "mime_type": "application/x-rust"
         },
         "output": {
-          "description": "Shell script",
+          "description": "Rust source",
           "extensions": [
-            "sh"
+            "rs"
           ],
           "group": "code",
           "is_text": true,
-          "label": "shell",
-          "mime_type": "text/x-shellscript"
+          "label": "rust",
+          "mime_type": "application/x-rust"
         },
-        "score": 0.9980000257492065
+        "score": 0.8949999809265137
       }
     }
   },
   {
-    "path": "README.md",
+    "path": "python/code.py",
     "result": {
       "status": "ok",
       "value": {
         "dl": {
-          "description": "Markdown document",
+          "description": "Python source",
           "extensions": [
-            "md",
-            "markdown"
+            "py",
+            "pyi"
           ],
-          "group": "text",
+          "group": "code",
           "is_text": true,
-          "label": "markdown",
-          "mime_type": "text/markdown"
+          "label": "python",
+          "mime_type": "text/x-python"
         },
         "output": {
-          "description": "Markdown document",
+          "description": "Python source",
           "extensions": [
-            "md",
-            "markdown"
+            "py",
+            "pyi"
           ],
-          "group": "text",
+          "group": "code",
           "is_text": true,
-          "label": "markdown",
-          "mime_type": "text/markdown"
+          "label": "python",
+          "mime_type": "text/x-python"
         },
-        "score": 0.9990000128746033
+        "score": 0.9589999914169312
       }
     }
   }
 ]
-+ magika test.sh --jsonl
-{"path":"test.sh","result":{"status":"ok","value":{"dl":{"description":"Shell script","extensions":["sh"],"group":"code","is_text":true,"label":"shell","mime_type":"text/x-shellscript"},"output":{"description":"Shell script","extensions":["sh"],"group":"code","is_text":true,"label":"shell","mime_type":"text/x-shellscript"},"score":0.9980000257492065}}}
-+ magika test.sh README.md --jsonl
-{"path":"test.sh","result":{"status":"ok","value":{"dl":{"description":"Shell script","extensions":["sh"],"group":"code","is_text":true,"label":"shell","mime_type":"text/x-shellscript"},"output":{"description":"Shell script","extensions":["sh"],"group":"code","is_text":true,"label":"shell","mime_type":"text/x-shellscript"},"score":0.9980000257492065}}}
-{"path":"README.md","result":{"status":"ok","value":{"dl":{"description":"Markdown document","extensions":["md","markdown"],"group":"text","is_text":true,"label":"markdown","mime_type":"text/markdown"},"output":{"description":"Markdown document","extensions":["md","markdown"],"group":"text","is_text":true,"label":"markdown","mime_type":"text/markdown"},"score":0.9990000128746033}}}
-+ magika test.sh --mime-type
-test.sh: text/x-shellscript
++ magika rust/code.rs --jsonl
+{"path":"rust/code.rs","result":{"status":"ok","value":{"dl":{"description":"Rust source","extensions":["rs"],"group":"code","is_text":true,"label":"rust","mime_type":"application/x-rust"},"output":{"description":"Rust source","extensions":["rs"],"group":"code","is_text":true,"label":"rust","mime_type":"application/x-rust"},"score":0.8949999809265137}}}
++ magika rust/code.rs python/code.py --jsonl
+{"path":"rust/code.rs","result":{"status":"ok","value":{"dl":{"description":"Rust source","extensions":["rs"],"group":"code","is_text":true,"label":"rust","mime_type":"application/x-rust"},"output":{"description":"Rust source","extensions":["rs"],"group":"code","is_text":true,"label":"rust","mime_type":"application/x-rust"},"score":0.8949999809265137}}}
+{"path":"python/code.py","result":{"status":"ok","value":{"dl":{"description":"Python source","extensions":["py","pyi"],"group":"code","is_text":true,"label":"python","mime_type":"text/x-python"},"output":{"description":"Python source","extensions":["py","pyi"],"group":"code","is_text":true,"label":"python","mime_type":"text/x-python"},"score":0.9589999914169312}}}
++ magika rust/code.rs --mime-type
+rust/code.rs: application/x-rust

--- a/rust/cli/test.sh
+++ b/rust/cli/test.sh
@@ -23,9 +23,10 @@ x cargo clippy -- --deny=warnings
 
 PATH=$(dirname $PWD)/target/release:$PATH
 
-info 'Test against the basic and mitra test suites'
+TEST_SUITES='basic mitra previous_missdetections'
+info "Test against the test suites: $TEST_SUITES"
 ( cd ../../tests_data
-  magika --format='%p: %l' --recursive basic mitra | while read line; do
+  magika --format='%p: %l' --recursive $TEST_SUITES | while read line; do
     file=${line%: *}
     directory=${file%/*}
     expected=${directory##*/}
@@ -35,14 +36,15 @@ info 'Test against the basic and mitra test suites'
 )
 
 info 'Test against expected output'
-( set -x
-  magika test.sh
-  magika test.sh --colors
-  magika test.sh --output-score
-  magika test.sh --json
-  magika test.sh README.md --json
-  magika test.sh --jsonl
-  magika test.sh README.md --jsonl
-  magika test.sh --mime-type
+( cd ../../tests_data/basic
+  set -x
+  magika rust/code.rs
+  magika rust/code.rs --colors
+  magika rust/code.rs --output-score
+  magika rust/code.rs --json
+  magika rust/code.rs python/code.py --json
+  magika rust/code.rs --jsonl
+  magika rust/code.rs python/code.py --jsonl
+  magika rust/code.rs --mime-type
 ) > output 2>&1
 git diff --exit-code -- output || error 'Unexpected output'


### PR DESCRIPTION
This is a follow-up of #632 