### PR TITLE
Fix CLI name in --version

### DIFF
--- a/rust/cli/CHANGELOG.md
+++ b/rust/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Patch
 
+- Fix the `--version` binary name from `magika-cli` to `magika`
 - Make sure ONNX Runtime telemetry is disabled
 - Change the default of the hidden flag `--num-tasks` from 1 to the number of CPUs
 

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -30,7 +30,7 @@ use tokio::io::AsyncReadExt;
 
 /// Determines the content type of files with deep-learning.
 #[derive(Parser)]
-#[command(version = Version, arg_required_else_help = true)]
+#[command(name = "magika", version = Version, arg_required_else_help = true)]
 struct Flags {
     /// List of paths to the files to analyze.
     ///


### PR DESCRIPTION
The default is the package name which is `magika-cli`. We want to use the binary name which is `magika`. Feature request on `clap` side: https://github.com/clap-rs/clap/issues/5738.