### PR TITLE
python: add API to get list of supported content types & fix ModelConfig types

### DIFF
--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -110,6 +110,9 @@ class Magika:
             raise Exception(f"Content must have type 'bytes', not {type(content)}.")
         return self._get_result_from_bytes(content)
 
+    def get_supported_content_types(self) -> List[ContentTypeLabel]:
+        return self._model_config.target_labels_space
+
     @staticmethod
     def _get_default_model_name() -> str:
         """This returns the default model name.

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -166,7 +166,27 @@ class Magika:
     @staticmethod
     def _load_model_config(model_config_path: Path) -> ModelConfig:
         config = json.loads(model_config_path.read_text())
-        return ModelConfig(**config)
+
+        return ModelConfig(
+            beg_size=config["beg_size"],
+            mid_size=config["mid_size"],
+            end_size=config["end_size"],
+            use_inputs_at_offsets=config["use_inputs_at_offsets"],
+            medium_confidence_threshold=config["medium_confidence_threshold"],
+            min_file_size_for_dl=config["min_file_size_for_dl"],
+            padding_token=config["padding_token"],
+            block_size=config["block_size"],
+            target_labels_space=[
+                ContentTypeLabel(ct_str) for ct_str in config["target_labels_space"]
+            ],
+            thresholds={
+                ContentTypeLabel(k): v for k, v in config["thresholds"].items()
+            },
+            overwrite_map={
+                ContentTypeLabel(k): ContentTypeLabel(v)
+                for k, v in config["overwrite_map"].items()
+            },
+        )
 
     def _init_onnx_session(self) -> rt.InferenceSession:
         start_time = time.time()

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -474,6 +474,13 @@ def test_access_backward_compatibility_layer() -> None:
         assert res.output.magic == res.value.output.description
 
 
+def test_get_supported_content_types() -> None:
+    m = Magika()
+    content_types = m.get_supported_content_types()
+    for ct in content_types:
+        assert isinstance(ct, ContentTypeLabel)
+
+
 def get_expected_content_type_label_from_test_file_path(
     test_path: Path,
 ) -> ContentTypeLabel:


### PR DESCRIPTION
Closes #271.
Closes #571.
Closes #712.