### PR TITLE
python: improve API usability and add backward compatibility layer

### DIFF
--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -19,10 +19,10 @@ __version__ = "0.6.0-dev0"
 import dotenv
 
 from magika import magika
-from magika.types import prediction_mode
+from magika.types import magika_error, prediction_mode
 
 Magika = magika.Magika
-MagikaError = magika.MagikaError
+MagikaError = magika_error.MagikaError
 PredictionMode = prediction_mode.PredictionMode
 
 dotenv.load_dotenv(dotenv.find_dotenv())

--- a/python/src/magika/logger.py
+++ b/python/src/magika/logger.py
@@ -40,8 +40,17 @@ class SimpleLogger:
     def raw_print_to_stdout(self, msg: str) -> None:
         self.raw_print(msg, file=sys.stdout)
 
-    def raw_print(self, msg: str, file: TextIO = sys.stderr) -> None:
-        print(msg, file=file)
+    def raw_print(
+        self, msg: str, file: Optional[TextIO] = None, flush: bool = True
+    ) -> None:
+        if file is None:
+            # We avoid using a default value for the `file` argument because we
+            # need to get the reference to the "current" stderr; if we used a
+            # default argument, we would just store the "current at
+            # instantiation time" stderr, which may not be the current one.
+            # This, in turn, could create problems for testing.
+            file = sys.stderr
+        print(msg, file=file, flush=flush)
 
     def debug(self, msg: str) -> None:
         if logging.DEBUG >= self.level:

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -29,6 +29,7 @@ from magika.seekable import Buffer, File, Seekable
 from magika.types import (
     ContentTypeInfo,
     ContentTypeLabel,
+    MagikaError,
     MagikaResult,
     ModelConfig,
     ModelFeatures,
@@ -783,7 +784,3 @@ class Magika:
 
             raw_predictions_list.append(batch_raw_predictions)
         return np.concatenate(raw_predictions_list)
-
-
-class MagikaError(Exception):
-    pass

--- a/python/src/magika/types/__init__.py
+++ b/python/src/magika/types/__init__.py
@@ -15,6 +15,7 @@
 
 from magika.types.content_type_info import ContentTypeInfo  # noqa: F401
 from magika.types.content_type_label import ContentTypeLabel  # noqa: F401
+from magika.types.magika_error import MagikaError  # noqa: F401
 from magika.types.magika_result import MagikaResult  # noqa: F401
 from magika.types.model import (  # noqa: F401
     ModelConfig,
@@ -28,6 +29,7 @@ from magika.types.statusor_magika_result import StatusOrMagikaResult  # noqa: F4
 __all__ = [
     "ContentTypeInfo",
     "ContentTypeLabel",
+    "MagikaError",
     "MagikaResult",
     "ModelConfig",
     "ModelFeatures",

--- a/python/src/magika/types/__init__.py
+++ b/python/src/magika/types/__init__.py
@@ -23,7 +23,7 @@ from magika.types.model import (  # noqa: F401
 )
 from magika.types.prediction_mode import PredictionMode  # noqa: F401
 from magika.types.status import Status  # noqa: F401
-from magika.types.statusor import StatusOr  # noqa: F401
+from magika.types.statusor_magika_result import StatusOrMagikaResult  # noqa: F401
 
 __all__ = [
     "ContentTypeInfo",
@@ -34,5 +34,5 @@ __all__ = [
     "ModelOutput",
     "PredictionMode",
     "Status",
-    "StatusOr",
+    "StatusOrMagikaResult",
 ]

--- a/python/src/magika/types/content_type_info.py
+++ b/python/src/magika/types/content_type_info.py
@@ -1,8 +1,11 @@
+import warnings
 from dataclasses import dataclass
 from typing import List
 
 from magika.logger import get_logger
 from magika.types.content_type_label import ContentTypeLabel
+
+warnings.simplefilter("always", DeprecationWarning)
 
 
 @dataclass(frozen=True)
@@ -16,9 +19,9 @@ class ContentTypeInfo:
 
     @property
     def ct_label(self) -> str:
-        log = get_logger()
-        log.warning(
-            "Deprecation warning: `.ct_label` is deprecated and will be removed in a future version. Use `.label` instead. Consult the documentation for more information."
+        warnings.warn(
+            "`.ct_label` is deprecated and will be removed in a future version. Use `.label` instead. Consult the documentation for more information.",
+            category=DeprecationWarning,
         )
         return str(self.label)
 
@@ -31,8 +34,8 @@ class ContentTypeInfo:
 
     @property
     def magic(self) -> str:
-        log = get_logger()
-        log.warning(
-            "Deprecation warning: `.magic` is deprecated and will be removed in a future version. Use `.description` instead. Consult the documentation for more information."
+        warnings.warn(
+            "`.magic` is deprecated and will be removed in a future version. Use `.description` instead. Consult the documentation for more information.",
+            category=DeprecationWarning,
         )
         return self.description

--- a/python/src/magika/types/content_type_info.py
+++ b/python/src/magika/types/content_type_info.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
+from magika.logger import get_logger
 from magika.types.content_type_label import ContentTypeLabel
 
 
@@ -12,3 +13,26 @@ class ContentTypeInfo:
     description: str
     extensions: List[str]
     is_text: bool
+
+    @property
+    def ct_label(self) -> str:
+        log = get_logger()
+        log.warning(
+            "Deprecation warning: `.ct_label` is deprecated and will be removed in a future version. Use `.label` instead. Consult the documentation for more information."
+        )
+        return str(self.label)
+
+    @property
+    def score(self) -> float:
+        error_msg = "Unsupported field error: `.score.` is not stored anymore in the `dl` or `output` objects; it is now stored in `MagikaResult`. Consult the documentation for more information."
+        log = get_logger()
+        log.error(error_msg)
+        raise AttributeError(error_msg)
+
+    @property
+    def magic(self) -> str:
+        log = get_logger()
+        log.warning(
+            "Deprecation warning: `.magic` is deprecated and will be removed in a future version. Use `.description` instead. Consult the documentation for more information."
+        )
+        return self.description

--- a/python/src/magika/types/magika_error.py
+++ b/python/src/magika/types/magika_error.py
@@ -1,0 +1,2 @@
+class MagikaError(Exception):
+    pass

--- a/python/src/magika/types/magika_result.py
+++ b/python/src/magika/types/magika_result.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from magika.logger import get_logger
 from magika.types.content_type_info import ContentTypeInfo
 
 
@@ -24,3 +25,16 @@ class MagikaResult:
     dl: ContentTypeInfo
     output: ContentTypeInfo
     score: float
+
+    # Access to .path is not supported anymore.  As we
+    # cannot implement this in a backward compatibile way, we raise an
+    # informative error message instead of leading to inscrutable crashes.
+    @property
+    def path(self) -> str:
+        error_msg = (
+            "Unsupported field error: `.path` is not stored anymore in `MagikaResult`. "
+            "Consult the documentation for more information."
+        )
+        log = get_logger()
+        log.error(error_msg)
+        raise AttributeError(error_msg)

--- a/python/src/magika/types/statusor_magika_result.py
+++ b/python/src/magika/types/statusor_magika_result.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Generic, Optional, TypeVar
+from typing import Optional
 
+from magika.types.content_type_info import ContentTypeInfo
+from magika.types.magika_result import MagikaResult
 from magika.types.status import Status
 
-T = TypeVar("T")
 
-
-class StatusOr(Generic[T]):
-    def __init__(self, *, status: Status = Status.OK, value: Optional[T] = None):
+class StatusOrMagikaResult:
+    def __init__(
+        self, *, status: Status = Status.OK, value: Optional[MagikaResult] = None
+    ):
         self._status = status
         self._value = value
 
@@ -41,11 +43,30 @@ class StatusOr(Generic[T]):
         return self._status
 
     @property
-    def value(self) -> T:
+    def value(self) -> MagikaResult:
         if self.ok:
             assert self._value is not None
             return self._value
         raise ValueError("value is not set when status != OK")
+
+    # In the vast majority of cases, Magika API would not return a status != OK
+    # (and there is no code path that leads `identify_bytes()` to return an
+    # error). To optimize for the most frequent scenario, we add the following
+    # properties to forward the underlying value. Clients that want to make use
+    # of the full power of the StatusOr[T] patter can still do so, but we do not
+    # force all clients, regardless of their complexity or criticality to use
+    # the more verbose `mr.value.output`.
+    @property
+    def dl(self) -> ContentTypeInfo:
+        return self.value.dl
+
+    @property
+    def output(self) -> ContentTypeInfo:
+        return self.value.output
+
+    @property
+    def score(self) -> float:
+        return self.value.score
 
     def __repr__(self) -> str:
         return str(self)

--- a/python/src/magika/types/statusor_magika_result.py
+++ b/python/src/magika/types/statusor_magika_result.py
@@ -68,6 +68,12 @@ class StatusOrMagikaResult:
     def score(self) -> float:
         return self.value.score
 
+    # Access to .path is not supported anymore. We forward .path access to the
+    # underlying value object, which will raise an informative exception.
+    @property
+    def path(self) -> str:
+        return self.value.path
+
     def __repr__(self) -> str:
         return str(self)
 

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from typing import Any, List
 
 import pytest
-from _pytest.capture import CaptureFixture
 
 from magika import Magika, PredictionMode
 from magika.types import (
@@ -444,10 +443,9 @@ def test_access_statusor_and_magika_result():
         _ = res.value.foo  # type: ignore[attr-defined]
 
 
-def test_access_backward_compatibility_layer(capsys: CaptureFixture):
+def test_access_backward_compatibility_layer() -> None:
     m = Magika()
 
-    capsys.readouterr
     res = m.identify_bytes(b"text")
     assert isinstance(res, StatusOrMagikaResult)
     assert isinstance(res.ok, bool)
@@ -458,34 +456,22 @@ def test_access_backward_compatibility_layer(capsys: CaptureFixture):
     assert isinstance(res.value.score, float)
 
     with pytest.raises(AttributeError):
-        _ = res.path  # type: ignore[attr-defined]
+        _ = res.path
 
-    _ = capsys.readouterr()
-    assert res.dl.ct_label == res.value.dl.label
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err.startswith("WARNING: Deprecation warning: ")
-    _ = capsys.readouterr()
-    assert res.output.ct_label == res.value.output.label
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err.startswith("WARNING: Deprecation warning: ")
+    with pytest.warns(DeprecationWarning):
+        assert res.dl.ct_label == res.value.dl.label
+    with pytest.warns(DeprecationWarning):
+        assert res.output.ct_label == res.value.output.label
 
     with pytest.raises(AttributeError):
-        _ = res.dl.score  # type: ignore[attr-defined]
+        _ = res.dl.score
     with pytest.raises(AttributeError):
-        _ = res.output.score  # type: ignore[attr-defined]
+        _ = res.output.score
 
-    _ = capsys.readouterr()
-    assert res.dl.magic == res.value.dl.description
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err.startswith("WARNING: Deprecation warning: ")
-    _ = capsys.readouterr()
-    assert res.output.magic == res.value.output.description
-    captured = capsys.readouterr()
-    assert captured.out == ""
-    assert captured.err.startswith("WARNING: Deprecation warning: ")
+    with pytest.warns(DeprecationWarning):
+        assert res.dl.magic == res.value.dl.description
+    with pytest.warns(DeprecationWarning):
+        assert res.output.magic == res.value.output.description
 
 
 def get_expected_content_type_label_from_test_file_path(


### PR DESCRIPTION
This PR makes progress on two aspects:
- simplify access to Magika's API results
- implement a backward compatibility layer, add deprecation warnings, and error out with meaningful messages when we cannot be fully backward compatible.

More context in the description of the two commits.