### PR TITLE
Python: allow to import `ContentTypeLabel` from `magika` module

### DIFF
--- a/python/scripts/run_quick_test_magika_module.py
+++ b/python/scripts/run_quick_test_magika_module.py
@@ -24,13 +24,12 @@ from pathlib import Path
 
 import click
 
-from magika import Magika
-from magika.types.content_type_label import ContentTypeLabel
+from magika import ContentTypeLabel, Magika, PredictionMode
 
 
 @click.command()
 def main() -> None:
-    m = Magika()
+    m = Magika(prediction_mode=PredictionMode.HIGH_CONFIDENCE)
 
     res = m.identify_bytes(b"text")
     assert res.dl.label == ContentTypeLabel.UNDEFINED

--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -19,10 +19,11 @@ __version__ = "0.6.0-dev0"
 import dotenv
 
 from magika import magika
-from magika.types import magika_error, prediction_mode
+from magika.types import content_type_label, magika_error, prediction_mode
 
 Magika = magika.Magika
 MagikaError = magika_error.MagikaError
+ContentTypeLabel = content_type_label.ContentTypeLabel
 PredictionMode = prediction_mode.PredictionMode
 
 dotenv.load_dotenv(dotenv.find_dotenv())


### PR DESCRIPTION
This allows to import `ContentTypeLabel` from the top magika module.

This is useful in situations like:
```
res = magika.identify_path(...)
if res.output.label == ContentTypeLabel.PYTHON:
    ...
```
