### PR TITLE
Also fix version in maturin sdist

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           path: rust/onnx/runtime/build/Linux
           key: maturin-${{ matrix.platform.target }}-${{ hashFiles('rust/onnx/build.sh') }}
-      # TODO(reyammer): Factorize this script into the one that also builds.
       - run: python3 ./python/scripts/fix_package_version.py
       - if: matrix.platform.runner == 'ubuntu-latest'
         name: Build wheels
@@ -72,6 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       # TODO(https://github.com/PyO3/maturin/issues/2244): Remove when released.
       - run: rm rust/cli/README.md
+      - run: python3 ./python/scripts/fix_package_version.py
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -11,7 +11,7 @@ on:
     - cron: '12 3 * * 4' # Refresh the cache weekly.
   workflow_dispatch:
   # Uncomment to test the workflow in a PR.
-  pull_request: # DO NOT MERGE: testing only
+  # pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -11,7 +11,7 @@ on:
     - cron: '12 3 * * 4' # Refresh the cache weekly.
   workflow_dispatch:
   # Uncomment to test the workflow in a PR.
-  # pull_request:
+  pull_request: # DO NOT MERGE: testing only
 
 permissions:
   contents: read

--- a/python/scripts/fix_package_version.py
+++ b/python/scripts/fix_package_version.py
@@ -20,6 +20,8 @@ import subprocess
 from pathlib import Path
 
 
+# TODO(reyammer): Factorize this script into build_python_package.py.
+# TODO(https://github.com/PyO3/maturin/issues/2163): Remove this file when fixed.
 def main() -> None:
     repo_root_dir = Path(__file__).parent.parent.parent
     python_root_dir = repo_root_dir / "python"


### PR DESCRIPTION
Of course in #747 I only checked the Linux wheel, not the sdist one. This PR fixes the version for sdist too.

[Here](https://github.com/google/magika/actions/runs/11530715610) are the wheels for inspection (only metadata inspection is needed, the workflow already runs the tests and the versions can be read in the output, including the wheel version).