### PR TITLE
Fix maturin workflow

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -2,6 +2,7 @@
 name: Maturin
 
 on:
+  pull_request:
   push:
     branches:
       - 'main'
@@ -10,8 +11,6 @@ on:
   schedule:
     - cron: '12 3 * * 4' # Refresh the cache weekly.
   workflow_dispatch:
-  # Uncomment to test the workflow in a PR.
-  # pull_request:
 
 permissions:
   contents: read
@@ -60,6 +59,7 @@ jobs:
       - run: python3 ./python/scripts/run_quick_test_magika_cli.py
       - run: python3 ./python/scripts/run_quick_test_magika_module.py
       - name: Upload wheels
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
@@ -79,6 +79,7 @@ jobs:
           args: --out=../dist
           working-directory: python
       - name: Upload sdist
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: wheels-sdist

--- a/rust/cli/test.sh
+++ b/rust/cli/test.sh
@@ -35,6 +35,9 @@ info "Test against the test suites: $TEST_SUITES"
   done
 )
 
+# We rely below on the fact that we don't have permission on /etc/shadow.
+[ $(id -u) -eq 0 ] && success "No more tests in Docker"
+
 info "Test exit code with at least one error"
 test_error() {
   files="$1"


### PR DESCRIPTION
We actually want to run the workflow on pull requests, simply not upload the artifacts. Otherwise we won't catch cases where a pull request breaks the "build".