### PR TITLE
Fix Rust lib and CLI versions

### DIFF
--- a/rust/cli/CHANGELOG.md
+++ b/rust/cli/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Changelog
 
-## 0.1.0-rc.1
+## 0.1.0-rc.2-dev
 
 ### Minor
 
 - Exit with non-zero code if at least one error was encountered (fixes #780)
+
+### Patch
+
+- Update dependencies
+
+## 0.1.0-rc.1
+
+### Minor
+
 - Print model version with `--version`
 - Change model from `standard_v2_0` to `standard_v2_1`
 

--- a/rust/cli/Cargo.lock
+++ b/rust/cli/Cargo.lock
@@ -460,7 +460,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "magika"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2-dev"
 dependencies = [
  "ndarray",
  "ort",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "magika-cli"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2-dev"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magika-cli"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2-dev"
 authors = ["Magika Developers <magika-dev@google.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -20,7 +20,7 @@ anyhow = "1.0.86"
 async-channel = "2.3.1"
 clap = { version = "4.5.9", features = ["cargo", "derive", "string"] }
 colored = "2.1.0"
-magika = { version = "=0.1.0-rc.1", path = "../lib", features = ["serde"] }
+magika = { version = "=0.1.0-rc.2-dev", path = "../lib", features = ["serde"] }
 num_cpus = "1.16.0"
 ort = "2.0.0-rc.8"
 serde = { version = "1.0.204", features = ["derive"] }

--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -175,4 +175,5 @@ Options:
 ```
 
 
-See the [docs on Magika's output](../../docs/magika_output.md) for more details about the output format.
+See the [docs on Magika's output](../../docs/magika_output.md) for more details about the output
+format.

--- a/rust/lib/CHANGELOG.md
+++ b/rust/lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-rc.2-dev
+
+### Patch
+
+- Update dependencies
+
 ## 0.1.0-rc.1
 
 ### Minor

--- a/rust/lib/Cargo.lock
+++ b/rust/lib/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "magika"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2-dev"
 dependencies = [
  "data-encoding",
  "flate2",

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magika"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2-dev"
 authors = ["Magika Developers <magika-dev@google.com>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
I forgot to bump them since the last release (essentially changes from #760 and #784).