### PR TITLE
python: constraint onnxruntime version to fix uv/macos problems

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,11 @@ Note that for version number starting with a `0`, i.e., `0.x.y`, a bump of `x`
 should be considered as a major (and thus potentially breaking) change. See
 semver guidelines for more details about this.
 
+## [0.6.0-rc3] - 2024-11-20
+
+- Fixed problems with installing Magika via `uv` on MacOS.
+
+
 ## [0.6.0-rc2] - 2024-11-19
 
 - Fixed manylinux wheel and other small fixes.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ["version"]
 
 dependencies = [
     "click>=8.1.7",
-    "onnxruntime>=1.19.0",
+    "onnxruntime>=1.19.0,<1.20",
     "numpy>=1.24; python_version < '3.12'",
     "numpy>=1.26; python_version >= '3.12' and python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",

--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-__version__ = "0.6.0-rc2"
+__version__ = "0.6.0-rc3"
 
 
 import dotenv

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -538,7 +538,7 @@ requires-dist = [
     { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.24" },
     { name = "numpy", marker = "python_full_version == '3.12.*'", specifier = ">=1.26" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "onnxruntime", specifier = ">=1.19.0" },
+    { name = "onnxruntime", specifier = ">=1.19.0,<1.20" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
 ]
 


### PR DESCRIPTION
`uv add onnxruntime` on MacOS currently fails as it resolves to 1.20.0, even if that can't be used on MacOS. This, in turns, make `uv add magika` fails as well.

Temporary fix is to help uv resolving to a proper version of onnxruntime.

Close #801.