### PR TITLE
Mark support for python 3.13 and add testing

### DIFF
--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -73,7 +73,7 @@ jobs:
       # We want to know in which exact situation the tests fail
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         platform:
           - runner: ubuntu-latest
             target: x86_64
@@ -151,7 +151,7 @@ jobs:
       # We want to know in which exact situation the tests fail
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         platform:
           - runner: ubuntu-latest
             target: x86_64
@@ -210,7 +210,7 @@ jobs:
       # We want to know in which exact situation the tests fail
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         platform:
           - runner: ubuntu-latest
             target: x86_64

--- a/.github/workflows/python-test-published-package.yml
+++ b/.github/workflows/python-test-published-package.yml
@@ -20,7 +20,7 @@ jobs:
   unit-testing:
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python-test-published-rc-package.yml
+++ b/.github/workflows/python-test-published-rc-package.yml
@@ -20,7 +20,7 @@ jobs:
   unit-testing:
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python-test-suite.yml
+++ b/.github/workflows/python-test-suite.yml
@@ -22,7 +22,7 @@ jobs:
   unit-testing:
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         os: [ "ubuntu-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,6 +10,11 @@ should be considered as a major (and thus potentially breaking) change. See
 semver guidelines for more details about this.
 
 
+## [Unreleased]
+
+- Mark python 3.13 as supported.
+
+
 ## [0.6.1] - 2025-03-19
 
 ### Overview

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: Unix",

--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-__version__ = "0.6.1"
+__version__ = "0.6.2-dev"
 
 
 import dotenv


### PR DESCRIPTION
Fixes: #811.

~Currently blocked as onnxruntime does not support python 3.13 yet.~ `onnxruntime 1.21.0` now supports python 3.13.