### PR TITLE
Extend magika wheels test to windows runner

### DIFF
--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -61,10 +61,7 @@ jobs:
         name: Check that `uv add magika.whl` works
         run: mkdir /tmp/test-uv && cp -vR dist/*.whl /tmp/test-uv && cd /tmp/test-uv && uv init && uv add ./$(\ls -1 *.whl | head -n 1)
       - if: matrix.platform.runner == 'windows-latest'
-        name: Install uv on Windows
-        run: powershell -Command "Invoke-WebRequest -Uri https://astral.sh/uv/0.4.7/install.ps1 -OutFile install.ps1; ./install.ps1"
-      - if: matrix.platform.runner == 'windows-latest'
-        name: Check that `uv add magika.whl` works on Windows
+        name: Check that magika install with uv works on Windows
         shell: pwsh
         run: |
           mkdir C:\test-uv

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -60,6 +60,19 @@ jobs:
       - if: matrix.platform.runner != 'windows-latest'
         name: Check that `uv add magika.whl` works
         run: mkdir /tmp/test-uv && cp -vR dist/*.whl /tmp/test-uv && cd /tmp/test-uv && uv init && uv add ./$(\ls -1 *.whl | head -n 1)
+      - if: matrix.platform.runner == 'windows-latest'
+        name: Install uv on Windows
+        run: powershell -Command "Invoke-WebRequest -Uri https://astral.sh/uv/0.4.7/install.ps1 -OutFile install.ps1; ./install.ps1"
+      - if: matrix.platform.runner == 'windows-latest'
+        name: Check that `uv add magika.whl` works on Windows
+        shell: pwsh
+        run: |
+          mkdir C:\test-uv
+          Copy-Item -Path dist\*.whl -Destination C:\test-uv
+          cd C:\test-uv
+          uv init
+          $wheel = Get-ChildItem -Filter *.whl | Select-Object -ExpandProperty Name
+          uv add ".\$wheel"
       - name: Install wheels
         run: python3 -m pip install $(python -c "import glob; print(glob.glob('dist/*.whl')[0])")
       - run: magika --version

--- a/.github/workflows/python-test-published-package.yml
+++ b/.github/workflows/python-test-published-package.yml
@@ -37,10 +37,7 @@ jobs:
         name: Check that magika can be installed with uv
         run: mkdir /tmp/test-uv && cd /tmp/test-uv && uv init && uv add magika && cd - && rm -rf /tmp/test-uv
       - if: matrix.platform.runner == 'windows-latest'
-        name: Install uv on Windows
-        run: powershell -Command "Invoke-WebRequest -Uri https://astral.sh/uv/0.4.7/install.ps1 -OutFile install.ps1; ./install.ps1"
-      - if: matrix.platform.runner == 'windows-latest'
-        name: Check that `uv add magika.whl` works on Windows
+        name: Check that magika install with uv works on Windows
         shell: pwsh
         run: |
           mkdir C:\test-uv

--- a/.github/workflows/python-test-published-package.yml
+++ b/.github/workflows/python-test-published-package.yml
@@ -36,6 +36,19 @@ jobs:
       - if: matrix.os != 'windows-latest' && matrix.python-version != '3.8' && matrix.python-version != '3.9'
         name: Check that magika can be installed with uv
         run: mkdir /tmp/test-uv && cd /tmp/test-uv && uv init && uv add magika && cd - && rm -rf /tmp/test-uv
+      - if: matrix.platform.runner == 'windows-latest'
+        name: Install uv on Windows
+        run: powershell -Command "Invoke-WebRequest -Uri https://astral.sh/uv/0.4.7/install.ps1 -OutFile install.ps1; ./install.ps1"
+      - if: matrix.platform.runner == 'windows-latest'
+        name: Check that `uv add magika.whl` works on Windows
+        shell: pwsh
+        run: |
+          mkdir C:\test-uv
+          Copy-Item -Path dist\*.whl -Destination C:\test-uv
+          cd C:\test-uv
+          uv init
+          $wheel = Get-ChildItem -Filter *.whl | Select-Object -ExpandProperty Name
+          uv add ".\$wheel"
       - name: Install magika with pip
         run: python3 -m pip install magika
       - run: python3 -c 'import magika; m = magika.Magika(); print(m)'

--- a/.github/workflows/python-test-published-rc-package.yml
+++ b/.github/workflows/python-test-published-rc-package.yml
@@ -36,10 +36,7 @@ jobs:
         name: Check that magika -rc can be installed with uv
         run: mkdir /tmp/test-uv && cd /tmp/test-uv && uv init && uv add --prerelease allow magika && cd - && rm -rf /tmp/test-uv
       - if: matrix.platform.runner == 'windows-latest'
-        name: Install uv on Windows
-        run: powershell -Command "Invoke-WebRequest -Uri https://astral.sh/uv/0.4.7/install.ps1 -OutFile install.ps1; ./install.ps1"
-      - if: matrix.platform.runner == 'windows-latest'
-        name: Check that `uv add magika.whl` works on Windows
+        name: Check that magika -rc install with uv works on Windows
         shell: pwsh
         run: |
           mkdir C:\test-uv
@@ -47,7 +44,7 @@ jobs:
           cd C:\test-uv
           uv init
           $wheel = Get-ChildItem -Filter *.whl | Select-Object -ExpandProperty Name
-          uv add ".\$wheel"
+          uv add --prerelease ".\$wheel"
       - name: Install magika with pip
         run: python3 -m pip install --pre magika
       - run: python3 -c 'import magika; m = magika.Magika(); print(m); print(magika.__version__)'

--- a/.github/workflows/python-test-published-rc-package.yml
+++ b/.github/workflows/python-test-published-rc-package.yml
@@ -35,6 +35,19 @@ jobs:
       - if: matrix.os != 'windows-latest'
         name: Check that magika -rc can be installed with uv
         run: mkdir /tmp/test-uv && cd /tmp/test-uv && uv init && uv add --prerelease allow magika && cd - && rm -rf /tmp/test-uv
+      - if: matrix.platform.runner == 'windows-latest'
+        name: Install uv on Windows
+        run: powershell -Command "Invoke-WebRequest -Uri https://astral.sh/uv/0.4.7/install.ps1 -OutFile install.ps1; ./install.ps1"
+      - if: matrix.platform.runner == 'windows-latest'
+        name: Check that `uv add magika.whl` works on Windows
+        shell: pwsh
+        run: |
+          mkdir C:\test-uv
+          Copy-Item -Path dist\*.whl -Destination C:\test-uv
+          cd C:\test-uv
+          uv init
+          $wheel = Get-ChildItem -Filter *.whl | Select-Object -ExpandProperty Name
+          uv add ".\$wheel"
       - name: Install magika with pip
         run: python3 -m pip install --pre magika
       - run: python3 -c 'import magika; m = magika.Magika(); print(m); print(magika.__version__)'


### PR DESCRIPTION
Resolves #805 

Updated the following workflows to install `uv` and verify that `uv add magika.whl` works on windows runner:

* `.github/workflows/python-build-package.yml`
* `.github/workflows/python-test-published-package.yml`
* `.github/workflows/python-test-published-rc-package.yml`