### PR TITLE
Fix nightly lints

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -26,6 +26,7 @@ jobs:
         working-directory: rust
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       matrix:
         toolchain: [stable, nightly]

--- a/rust/gen/src/main.rs
+++ b/rust/gen/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
     let model_name = std::fs::read_link("model")?;
     let model_name = model_name
         .components()
-        .last()
+        .next_back()
         .context("model link")?
         .as_os_str()
         .to_str()


### PR DESCRIPTION
Also do not fail the workflow when nightly fails. The situations where the nightly job fails but the stable job doesn't, shouldn't block merging a PR. In particular, nightly is not hermetic (by design), so shouldn't block merging a PR for this simple reason alone.

Fixes #867