### PR TITLE
python: add OverwriteReason field to MagikaPrediction

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -14,6 +14,7 @@ semver guidelines for more details about this.
 - Upgrade model from `standard_v2_1` to `standard_v3_0`. This should result in a 3x faster inference speed, with the same overall accuracy. This new model should also be ~20% faster than `standard_v1`.
 - New API: `get_output_content_types()`. This API returns the list of all possible outputs by the module. I.e., all possible values for `MagikaResult.prediction.output.label`. This is the list that is relevant for most clients.
 - New API: `get_model_content_types()`. This API returns the list of all possible outputs of the deep learning model. I.e., all possible values for `MagikaResult.prediction.dl.label`. Note that, in general, the list of "model outputs" is different than the "tool outputs" as in some cases the model is not even used, or the model's output is overwritten due to a low-confidence score, or other reasons. This API is useful mostly for debugging purposes; the vast majority of client should use `get_output_content_types()`.
+- `MagikaPrediction` now has an `overwrite_reason` field, specifying why and if the model's prediction was overwritten.
 
 ## [0.6.0-rc3] - 2024-11-20
 

--- a/python/scripts/magika_python_module_tester.py
+++ b/python/scripts/magika_python_module_tester.py
@@ -27,6 +27,7 @@ import click
 from magika import Magika, MagikaError, PredictionMode, colors
 from magika.logger import get_logger
 from magika.types import ContentTypeLabel, MagikaResult
+from magika.types.overwrite_reason import OverwriteReason
 
 VERSION = importlib.metadata.version("magika")
 
@@ -291,8 +292,10 @@ def main(
                             result.prediction.dl.label != ContentTypeLabel.UNDEFINED
                             and result.prediction.dl.label
                             != result.prediction.output.label
+                            and result.prediction.overwrite_reason
+                            == OverwriteReason.NONE
                         ):
-                            # it seems that we had a too-low confidence prediction
+                            # It seems that we had a low-confidence prediction
                             # from the model. Let's warn the user about our best
                             # bet.
                             output += (

--- a/python/src/magika/types/__init__.py
+++ b/python/src/magika/types/__init__.py
@@ -23,6 +23,7 @@ from magika.types.model import (  # noqa: F401
     ModelFeatures,
     ModelOutput,
 )
+from magika.types.overwrite_reason import OverwriteReason  # noqa: F401
 from magika.types.prediction_mode import PredictionMode  # noqa: F401
 from magika.types.status import Status  # noqa: F401
 
@@ -35,6 +36,7 @@ __all__ = [
     "ModelConfig",
     "ModelFeatures",
     "ModelOutput",
+    "OverwriteReason",
     "PredictionMode",
     "Status",
 ]

--- a/python/src/magika/types/overwrite_reason.py
+++ b/python/src/magika/types/overwrite_reason.py
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
 
-from dataclasses import dataclass
+import enum
 
-from magika.types.content_type_info import ContentTypeInfo
-from magika.types.overwrite_reason import OverwriteReason
+from magika.types.strenum import LowerCaseStrEnum
 
 
-@dataclass(frozen=True)
-class MagikaPrediction:
-    dl: ContentTypeInfo
-    output: ContentTypeInfo
-    score: float
-    overwrite_reason: OverwriteReason
+class OverwriteReason(LowerCaseStrEnum):
+    NONE = enum.auto()
+    LOW_CONFIDENCE = enum.auto()
+    OVERWRITE_MAP = enum.auto()

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -27,6 +27,7 @@ from magika.types import (
     MagikaResult,
     Status,
 )
+from magika.types.overwrite_reason import OverwriteReason
 from tests import utils
 
 
@@ -185,66 +186,57 @@ def test_magika_module_with_python_and_non_python_content() -> None:
 def test_magika_module_with_different_prediction_modes() -> None:
     model_dir = utils.get_default_model_dir()
     m = Magika(model_dir=model_dir, prediction_mode=PredictionMode.BEST_GUESS)
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.40)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.40) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.60)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.60) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
 
     m = Magika(model_dir=model_dir, prediction_mode=PredictionMode.MEDIUM_CONFIDENCE)
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01)
-        == ContentTypeLabel.TXT
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01) == (
+        ContentTypeLabel.TXT,
+        OverwriteReason.LOW_CONFIDENCE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(
-            ContentTypeLabel.PYTHON, m._model_config.medium_confidence_threshold - 0.01
-        )
-        == ContentTypeLabel.TXT
+    assert m._get_output_ct_label_from_dl_result(
+        ContentTypeLabel.PYTHON, m._model_config.medium_confidence_threshold - 0.01
+    ) == (ContentTypeLabel.TXT, OverwriteReason.LOW_CONFIDENCE)
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.60) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.60)
-        == ContentTypeLabel.PYTHON
-    )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
 
     m = Magika(model_dir=model_dir, prediction_mode=PredictionMode.HIGH_CONFIDENCE)
     high_confidence_threshold = m._model_config.thresholds.get(
         ContentTypeLabel.PYTHON, m._model_config.medium_confidence_threshold
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01)
-        == ContentTypeLabel.TXT
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01) == (
+        ContentTypeLabel.TXT,
+        OverwriteReason.LOW_CONFIDENCE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(
-            ContentTypeLabel.PYTHON, high_confidence_threshold - 0.01
-        )
-        == ContentTypeLabel.TXT
-    )
-    assert (
-        m._get_output_ct_label_from_dl_result(
-            ContentTypeLabel.PYTHON, high_confidence_threshold + 0.01
-        )
-        == ContentTypeLabel.PYTHON
-    )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(
+        ContentTypeLabel.PYTHON, high_confidence_threshold - 0.01
+    ) == (ContentTypeLabel.TXT, OverwriteReason.LOW_CONFIDENCE)
+    assert m._get_output_ct_label_from_dl_result(
+        ContentTypeLabel.PYTHON, high_confidence_threshold + 0.01
+    ) == (ContentTypeLabel.PYTHON, OverwriteReason.NONE)
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
 
     # test that the default is HIGH_CONFIDENCE
@@ -252,25 +244,19 @@ def test_magika_module_with_different_prediction_modes() -> None:
     high_confidence_threshold = m._model_config.thresholds.get(
         ContentTypeLabel.PYTHON, m._model_config.medium_confidence_threshold
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01)
-        == ContentTypeLabel.TXT
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.01) == (
+        ContentTypeLabel.TXT,
+        OverwriteReason.LOW_CONFIDENCE,
     )
-    assert (
-        m._get_output_ct_label_from_dl_result(
-            ContentTypeLabel.PYTHON, high_confidence_threshold - 0.01
-        )
-        == ContentTypeLabel.TXT
-    )
-    assert (
-        m._get_output_ct_label_from_dl_result(
-            ContentTypeLabel.PYTHON, high_confidence_threshold + 0.01
-        )
-        == ContentTypeLabel.PYTHON
-    )
-    assert (
-        m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99)
-        == ContentTypeLabel.PYTHON
+    assert m._get_output_ct_label_from_dl_result(
+        ContentTypeLabel.PYTHON, high_confidence_threshold - 0.01
+    ) == (ContentTypeLabel.TXT, OverwriteReason.LOW_CONFIDENCE)
+    assert m._get_output_ct_label_from_dl_result(
+        ContentTypeLabel.PYTHON, high_confidence_threshold + 0.01
+    ) == (ContentTypeLabel.PYTHON, OverwriteReason.NONE)
+    assert m._get_output_ct_label_from_dl_result(ContentTypeLabel.PYTHON, 0.99) == (
+        ContentTypeLabel.PYTHON,
+        OverwriteReason.NONE,
     )
 
 


### PR DESCRIPTION
Fixes #873.

This is useful to signal to external clients why and if the model's prediction was overwritten. As of now, it can either happen because of a low-confidence model prediction, or because of the model's overwrite_map config.