### PR TITLE
gh: disable crlf conversion on all platforms via gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests_data/** -text

--- a/.github/workflows/js-publish.yml
+++ b/.github/workflows/js-publish.yml
@@ -11,8 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # pin@v4
         with:

--- a/.github/workflows/js-test.yml
+++ b/.github/workflows/js-test.yml
@@ -24,8 +24,6 @@ jobs:
         os: [ "ubuntu-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # pin@v4
         with:

--- a/.github/workflows/python-build-package.yml
+++ b/.github/workflows/python-build-package.yml
@@ -28,8 +28,6 @@ jobs:
           - runner: macos-14
             target: aarch64
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # pin@v5

--- a/.github/workflows/python-test-published-package.yml
+++ b/.github/workflows/python-test-published-package.yml
@@ -24,8 +24,6 @@ jobs:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # pin@v5

--- a/.github/workflows/python-test-published-rc-package.yml
+++ b/.github/workflows/python-test-published-rc-package.yml
@@ -24,8 +24,6 @@ jobs:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # pin@v5

--- a/.github/workflows/python-test-suite.yml
+++ b/.github/workflows/python-test-suite.yml
@@ -26,9 +26,6 @@ jobs:
         os: [ "ubuntu-latest", "macos-latest" ]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
-
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
 
       - name: Setup Python

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -19,8 +19,6 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
         with:
           fetch-depth: 0
@@ -33,8 +31,6 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - run: rustup default ${{ matrix.toolchain }}
       - run: rustup component add rustfmt clippy
@@ -46,8 +42,6 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
     steps:
-      - name: Disable automatic git CRLF conversion
-        run: git config --global core.autocrlf false
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # pin@v4
       - run: cargo build --release
         working-directory: rust/cli


### PR DESCRIPTION
This fixes #899 in a cleaner way, and somehow reverts #900.