### PR TITLE
python: relax constraint on onnxruntime

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ["version"]
 
 dependencies = [
     "click>=8.1.7",
-    "onnxruntime>=1.17.0,<1.20",
+    "onnxruntime>=1.17.0",
     "numpy>=1.24; python_version < '3.12'",
     "numpy>=1.26; python_version >= '3.12' and python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",


### PR DESCRIPTION
With a past version of uv, `uv add onnxruntime` would fail. To address that, we overly constrained the allowed onnxruntime version (#801).

More recent versions of uv have now fixed this
(https://github.com/astral-sh/uv/pull/9827), so we remove the constraint.

Fixes #835.