### PR TITLE
gh workflow: bump uv version in public pip package testers

### DIFF
--- a/.github/workflows/python-test-published-package.yml
+++ b/.github/workflows/python-test-published-package.yml
@@ -32,7 +32,7 @@ jobs:
       # uv's oneline below does not work on windows; uv add magika==0.5.1 is known to not work with python 3.8 and 3.9
       - if: matrix.os != 'windows-latest' && matrix.python-version != '3.8' && matrix.python-version != '3.9'
         name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.4.7/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.5.22/install.sh | sh
       - if: matrix.os != 'windows-latest' && matrix.python-version != '3.8' && matrix.python-version != '3.9'
         name: Check that magika can be installed with uv
         run: mkdir /tmp/test-uv && cd /tmp/test-uv && uv init && uv add magika && cd - && rm -rf /tmp/test-uv
@@ -43,6 +43,7 @@ jobs:
           mkdir C:\test-uv
           Copy-Item -Path dist\*.whl -Destination C:\test-uv
           cd C:\test-uv
+          $env:PATH += ";$HOME/.local/bin"
           uv init
           $wheel = Get-ChildItem -Filter *.whl | Select-Object -ExpandProperty Name
           uv add ".\$wheel"

--- a/.github/workflows/python-test-published-rc-package.yml
+++ b/.github/workflows/python-test-published-rc-package.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '${{ matrix.python-version }}'
       - if: matrix.os != 'windows-latest'
         name: Install uv
-        run: curl -LsSf https://astral.sh/uv/0.5.4/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.5.22/install.sh | sh
       - if: matrix.os != 'windows-latest'
         name: Check that magika -rc can be installed with uv
         run: mkdir /tmp/test-uv && cd /tmp/test-uv && uv init && uv add --prerelease allow magika && cd - && rm -rf /tmp/test-uv
@@ -42,6 +42,7 @@ jobs:
           mkdir C:\test-uv
           Copy-Item -Path dist\*.whl -Destination C:\test-uv
           cd C:\test-uv
+          $env:PATH += ";$HOME/.local/bin"
           uv init
           $wheel = Get-ChildItem -Filter *.whl | Select-Object -ExpandProperty Name
           uv add --prerelease ".\$wheel"


### PR DESCRIPTION
Installing the latest -rc with uv still fails (#922), but this PR is useful anyways.