### PR TITLE
Python: add new `identify_stream` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Options:
 
 While the command line client is handy for many use cases, it may not be the most suitable for automated workflows. Thus, Magika comes with bindings for Python and other languages (see the [Bindings section](#bindings) below for more details).
 
-Here is a couple of examples on how to use the `Magika` Python module:
+Here is a few examples on how to use the `Magika` Python module:
 
 ```python
 >>> from magika import Magika
@@ -237,6 +237,15 @@ javascript
 >>> from magika import Magika
 >>> m = Magika()
 >>> res = m.identify_path('./tests_data/basic/ini/doc.ini')
+>>> print(res.output.label)
+ini
+```
+
+```python
+>>> from magika import Magika
+>>> m = Magika()
+>>> with open('./tests_data/basic/ini/doc.ini', 'rb') as f:
+>>>     res = m.identify_stream(f)
 >>> print(res.output.label)
 ini
 ```

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,10 @@ Note that for version number starting with a `0`, i.e., `0.x.y`, a bump of `x`
 should be considered as a major (and thus potentially breaking) change. See
 semver guidelines for more details about this.
 
+## [Unreleased]
+
+- Add new `identify_stream(stream: typing.BinaryIO)` API to infer the content type from an already-open binary stream.
+
 ## [0.6.1-rc2] - 2025-03-11
 
 - Upgrade model from `standard_v3_0` to `standard_v3_1`. See details in the [models' changelog notes](../assets/models/CHANGELOG.md).

--- a/python/README.md
+++ b/python/README.md
@@ -173,6 +173,8 @@ Check the [Rust CLI docs](https://github.com/google/magika/blob/main/rust/cli/RE
 
 > Note: The Python API introduced in version `0.6.0` closely resembles the previous version, but includes several enhancements and a few breaking changes. Migrating existing clients should be relatively straightforward. Where possible, we have maintained compatibility with the old API and added deprecation warnings. For a complete list of changes and migration guidance, consult the [CHANGELOG.md](https://github.com/google/magika/blob/main/python/CHANGELOG.md).
 
+Here is a few examples on how to use the `Magika` Python module:
+
 ```python
 >>> from magika import Magika
 >>> m = Magika()
@@ -185,6 +187,15 @@ javascript
 >>> from magika import Magika
 >>> m = Magika()
 >>> res = m.identify_path('./tests_data/basic/ini/doc.ini')
+>>> print(res.output.label)
+ini
+```
+
+```python
+>>> from magika import Magika
+>>> m = Magika()
+>>> with open('./tests_data/basic/ini/doc.ini', 'rb') as f:
+>>>     res = m.identify_stream(f)
 >>> print(res.output.label)
 ini
 ```
@@ -204,12 +215,13 @@ The constructor accepts the following optional arguments:
 - `prediction_mode`: which prediction mode to use; defaults to `PredictionMode.HIGH_CONFIDENCE`.
 - `no_dereference`: controls whether symlinks should be dereferenced; defaults to `False`.
 
-Once instantiated, the `Magika` object exposes three methods:
+Once instantiated, the `Magika` object exposes methods to identify the content type of a `bytes` object, of files identified by their paths, and of an already-open binary stream:
 - `magika.identify_bytes(b"test")`: takes as input a stream of bytes and predict its content type.
 - `magika.identify_path("test.txt")`: takes as input one `str | os.PathLike` object and predicts its content type.
 - `magika.identify_paths(["test.txt", "test2.txt"])`: takes as input a list of `str | os.PathLike` objects and returns the predicted type for each of them.
+- `magika.identify_stream(stream: typing.BinaryIO)`: takes as input an *already open* binary file-like object (e.g., the output of `open(file_path, 'rb')`) and returns its predicted content type. Keep in mind that Magika will `seek()` around the stream, and that the stream *is not closed* (closing is the responsibility of the caller).
 
-If you are dealing with large files, the `identify_path` and `identify_paths` variants are generally better: their implementation `seek()`s around the file to extract the needed features, without loading the entire content in memory.
+If you are dealing with large files, the `identify_path`, `identify_paths`, and `identify_stream` variants are generally better: their implementation `seek()`s around the file/stream to extract the needed features, without loading the entire content in memory.
 
 These API returns an object of type [`MagikaResult`](https://github.com/google/magika/blob/main/python/src/magika/types/magika_result.py), an [`absl::StatusOr`](https://abseil.io/docs/cpp/guides/status)-like wrapper around [`MagikaPrediction`](https://github.com/google/magika/blob/main/python/src/magika/types/magika_prediction.py), which exposes the same information discussed in the [Magika's output documentation](https://github.com/google/magika/blob/main/docs/concepts.md).
 

--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-__version__ = "0.6.1-rc2"
+__version__ = "0.6.1-rc3-dev"
 
 
 import dotenv

--- a/python/src/magika/seekable.py
+++ b/python/src/magika/seekable.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import abc
+import io
 from pathlib import Path
+from typing import BinaryIO
 
 
 class Seekable(abc.ABC):
@@ -61,3 +63,18 @@ class Buffer(Seekable):
 
         assert offset + size <= self.size
         return self._buffer[offset : offset + size]
+
+
+class Stream(Seekable):
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+        stream.seek(0, io.SEEK_END)
+        self._size = stream.tell()
+
+    def read_at(self, offset: int, size: int) -> bytes:
+        if size == 0:
+            return b""
+
+        assert offset + size <= self.size
+        self._stream.seek(offset)
+        return self._stream.read(size)


### PR DESCRIPTION
This PR adds a new `identify_stream` API, as suggested in #970. With this API, one can identify the content type of an already-open stream; the implementation does not read the full file, and it just `seek()`s around. This new API avoids clients to be forced to (directly or indirectly) read the full file's content in memory.

Fixes #970.