### PR TITLE
python: rename `get_version` => `get_module_version` method

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ semver guidelines for more details about this.
 
 - Add new `identify_stream(stream: typing.BinaryIO)` API to infer the content type from an already-open binary stream (https://github.com/google/magika/issues/970).
 - Improved path handling in `identify_path` and `identify_paths`. These functions now accept `Union[str, os.PathLike]` objects, eliminating the need to import `pathlib.Path` for basic usage (https://github.com/google/magika/issues/935).
+- Rename `get_version` => `get_module_version` method to help disambiguate which "thing" the version is referring to.
 
 ## [0.6.1-rc2] - 2025-03-11
 

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -105,9 +105,9 @@ class Magika:
         return str(self)
 
     def __str__(self) -> str:
-        return f'Magika(version="{self.get_version()}", model_name="{self.get_model_name()}")'
+        return f'Magika(module_version="{self.get_module_version()}", model_name="{self.get_model_name()}")'
 
-    def get_version(self) -> str:
+    def get_module_version(self) -> str:
         return str(__import__(self.__module__).__version__)
 
     def get_model_name(self) -> str:

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -38,6 +38,13 @@ def test_magika_module_check_version() -> None:
 
     assert isinstance(magika_module.__version__, str)
 
+    m = Magika()
+    assert m.get_module_version() == magika_module.__version__
+
+    # Check that, when we don't specify `model_dir`, Magika uses the default
+    # model.
+    assert m.get_model_name() == m._get_default_model_name()
+
 
 @pytest.mark.smoketest
 def test_magika_module_with_one_test_file() -> None:
@@ -532,6 +539,11 @@ def test_get_model_and_output_content_types() -> None:
     output_content_types_set = set(output_content_types)
     model_content_types = m.get_model_content_types()
     model_content_types_set = set(model_content_types)
+
+    assert isinstance(output_content_types, List)
+    assert len(output_content_types) > 0
+    assert isinstance(model_content_types, List)
+    assert len(model_content_types) > 0
 
     for ct in output_content_types:
         assert isinstance(ct, ContentTypeLabel)


### PR DESCRIPTION
This helps disambiguate which "thing" the version is referring to.