### PR TITLE
python bugfix: limit the number of bytes we read in case of an input with just many whitespaces

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ semver guidelines for more details about this.
 ## [Unreleased]
 
 - Mark python 3.13 as supported.
+- Bugfix: limit the number of bytes we read in case of an input with just many whitespaces. ([#1015](https://github.com/google/magika/pull/1015))
 
 
 ## [0.6.1] - 2025-03-19

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -875,7 +875,8 @@ class Magika:
                 # If the n-th token is padding, then it means that,
                 # post-stripping, we do not have enough meaningful
                 # bytes.
-                result = self._get_result_from_few_bytes(content)
+                bytes_to_read = min(len(content), self._model_config.block_size)
+                result = self._get_result_from_few_bytes(content[0:bytes_to_read])
                 return result, None
 
             else:
@@ -938,8 +939,9 @@ class Magika:
                 # If the n-th token is padding, then it means that,
                 # post-stripping, we do not have enough meaningful
                 # bytes.
+                bytes_to_read = min(bytes_stream_size, self._model_config.block_size)
                 stream.seek(0)
-                content = stream.read()
+                content = stream.read(bytes_to_read)
                 result = self._get_result_from_few_bytes(content)
                 return result, None
 


### PR DESCRIPTION
Fixes #1014.