### PR TITLE
python: do not alter warnings' filter

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -14,6 +14,7 @@ semver guidelines for more details about this.
 
 - Mark python 3.13 as supported.
 - Bugfix: limit the number of bytes we read in case of an input with just many whitespaces. ([#1015](https://github.com/google/magika/pull/1015))
+- Bugfix: do not alter warnings' simplefilter as this has visible side effects for other modules. ([#1017](https://github.com/google/magika/pull/1017))
 
 
 ## [0.6.1] - 2025-03-19

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,8 +1,6 @@
 [pytest]
 log_cli = 1
 log_level = WARNING
-filterwarnings =
-    ignore::DeprecationWarning
 
 markers =
     smoketest

--- a/python/src/magika/types/content_type_info.py
+++ b/python/src/magika/types/content_type_info.py
@@ -5,8 +5,6 @@ from typing import List
 from magika.logger import get_logger
 from magika.types.content_type_label import ContentTypeLabel
 
-warnings.simplefilter("always", DeprecationWarning)
-
 
 @dataclass(frozen=True)
 class ContentTypeInfo:
@@ -22,6 +20,7 @@ class ContentTypeInfo:
         warnings.warn(
             "`.ct_label` is deprecated and will be removed in a future version. Use `.label` instead. Consult the documentation for more information.",
             category=DeprecationWarning,
+            stacklevel=2,
         )
         return str(self.label)
 
@@ -37,5 +36,6 @@ class ContentTypeInfo:
         warnings.warn(
             "`.magic` is deprecated and will be removed in a future version. Use `.description` instead. Consult the documentation for more information.",
             category=DeprecationWarning,
+            stacklevel=2,
         )
         return self.description


### PR DESCRIPTION
We recently added a couple of `DeprecationWarning`s, and to make sure users would see them, we also set `warnings.simplefilter` to `always`. However, this inadvertently modified the warnings' settings for all other modules as well. This is not nice.

This patch removes the edit to the simplefilter (going back to default) and uses `stacklevel`s `warn` argument to increase the `DeprecationWarning` visibiilty. This is not a silver bullet as if one uses the deprecated property "three levels or more" deep, the warning is not visible.

To fix this limitation, python 3.12 added the `skip_file_prefixes` argument to `warn` (https://github.com/python/cpython/pull/100840), but it's not worth using it and break compatibility with older versions of python. `stacklevel=2` should not create any problems (see https://github.com/python/cpython/issues/88462).

Fixes #1006.