### PR TITLE
python: identify_stream now seeks back to initial stream position before returning

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ semver guidelines for more details about this.
 ## [Unreleased]
 
 - Mark python 3.13 as supported.
+- `identify_stream()` now restores the stream's original position after reading from it, preventing side effects on subsequent stream operations. ([#1020](https://github.com/google/magika/pull/1020))
 - Bugfix: limit the number of bytes we read in case of an input with just many whitespaces. ([#1015](https://github.com/google/magika/pull/1015))
 - Bugfix: do not alter warnings' simplefilter as this has visible side effects for other modules. ([#1017](https://github.com/google/magika/pull/1017))
 - Add `asdict()` utility method to `MagikaResult`.

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -178,7 +178,13 @@ class Magika:
         ):
             raise TypeError("Input stream must have seek, read, and tell methods.")
 
-        return self._get_result_from_seekable(Seekable(stream))
+        try:
+            current_position = stream.tell()
+            result = self._get_result_from_seekable(Seekable(stream))
+        finally:
+            # seek to the previous position even in case of exceptions
+            stream.seek(current_position)
+        return result
 
     def get_output_content_types(self) -> List[ContentTypeLabel]:
         """This method returns the list of all possible output content types of

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -222,6 +222,26 @@ def test_magika_module_with_python_and_non_python_content() -> None:
     assert res.prediction.output.label == ContentTypeLabel.TXT
 
 
+def test_magika_module_identify_stream_does_not_alter_position() -> None:
+    m = Magika()
+
+    contents = [
+        b"",
+        b"short",
+        b"A" * 100,
+        b"A" * 1000,
+        b"A" * 10000,
+    ]
+    for content in contents:
+        stream = io.BytesIO(content)
+        # seek to a specific non-special position
+        pos = min(2, len(content))
+        stream.seek(pos)
+        res = m.identify_stream(stream)
+        assert res.ok
+        assert stream.tell() == pos
+
+
 def test_magika_module_with_whitespaces() -> None:
     m = Magika()
 


### PR DESCRIPTION
`identify_stream()` now restores the stream's original position after reading from it, preventing side effects on subsequent stream operations.

Fixes #1018.