### PR TITLE
Simplify Rust code

### DIFF
--- a/rust/gen/src/main.rs
+++ b/rust/gen/src/main.rs
@@ -17,7 +17,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use serde::Deserialize;
 
 fn main() -> Result<()> {
@@ -132,9 +132,9 @@ fn generate_model_config(content_types: &[String], model_config: ModelConfig) ->
     writeln!(output, "use crate::ContentType;\n")?;
     writeln!(output, "pub(crate) const CONFIG: ModelConfig = ModelConfig {{")?;
     writeln!(output, "    beg_size: {beg_size},")?;
-    writeln!(output, "    mid_size: {mid_size},")?;
+    ensure!(mid_size == 0, "unsupported mid_size");
     writeln!(output, "    end_size: {end_size},")?;
-    writeln!(output, "    use_inputs_at_offsets: {use_inputs_at_offsets},")?;
+    ensure!(!use_inputs_at_offsets, "unsupported use_inputs_at_offsets");
     writeln!(output, "    min_file_size_for_dl: {min_file_size_for_dl},")?;
     writeln!(output, "    padding_token: {padding_token},")?;
     writeln!(output, "    block_size: {block_size},")?;

--- a/rust/lib/CHANGELOG.md
+++ b/rust/lib/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Minor
 
+- Remove features extraction logic of older models
 - Use the `standard_v3_3` model instead of `standard_v3_2` (see [model changelog])
 - Add `OverwriteReason` to document why the inferred content type is overwritten
 

--- a/rust/lib/src/model.rs
+++ b/rust/lib/src/model.rs
@@ -22,9 +22,7 @@ use crate::ContentType;
 
 pub(crate) const CONFIG: ModelConfig = ModelConfig {
     beg_size: 1024,
-    mid_size: 0,
     end_size: 1024,
-    use_inputs_at_offsets: false,
     min_file_size_for_dl: 8,
     padding_token: 256,
     block_size: 4096,


### PR DESCRIPTION
According to #1055 we have `mid_size == 0` and `use_inputs_at_offsets == false`. This simplifies the code significantly. The simplification is fine to do because we only support one model and it's embedded. Once we'll support multiple models (in particular dynamic loading), we'll need features extraction to work for all possible models (possibly having multiple features extraction functions).