### PR TITLE
Pin onnxruntime on Windows

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "click>=8.1.7",
     "onnxruntime>=1.17.0 ; python_version > '3.9'",
     "onnxruntime>=1.17.0, <1.20.0 ; python_version <= '3.9'",
+    "onnxruntime<=1.20.1 ; sys_platform == 'win32'",
     "numpy>=1.24; python_version < '3.12'",
     "numpy>=1.26; python_version >= '3.12' and python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",


### PR DESCRIPTION
Fixes error encountered on Windows:
```
DLL load failed while importing onnxruntime_pybind11_state: A dynamic link library (DLL) initialization routine failed.
```

Error is due to a new VC++ requirement beginning with v1.21.0: https://github.com/Microsoft/onnxruntime/releases/tag/v1.21.0


closes #1092