### PR TITLE
Change the default performance tuning configuration

### DIFF
--- a/rust/cli/CHANGELOG.md
+++ b/rust/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.1.3-dev
 
+### Minor
+
+- Change performance tuning configuration
+
 ### Patch
 
 - Update dependencies


### PR DESCRIPTION
Since #1098, we use one session per task. This has an impact on the tuning configuration, in particular we need to scale down `--intra-threads` appropriately.