### PR TITLE
Keep ia0 as owner of rust Changelogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,9 @@
 *.md @reyammer
 /tests_data/ @reyammer
 
+# Julien still owns the Rust changelogs
+/rust/**/CHANGELOG.md @ia0
+
 # Luca owns the JS code, docs, and website
 /js/ @invernizzi
 /docs/js.md @invernizzi


### PR DESCRIPTION
The `*.md` rule for documentation is a bit strong. The intent was only to capture READMEs under rust, so this PR explicitly excludes the CHANGELOGs from that rule. This makes it possible to do pure code changes to the Rust CLI and library without double approvals.