### PR TITLE
python: prepare for release of 1.0.1

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,10 +9,13 @@ Note that for version number starting with a `0`, i.e., `0.x.y`, a bump of `x`
 should be considered as a major (and thus potentially breaking) change. See
 semver guidelines for more details about this.
 
+## [1.0.1] - 2025-10-31
+- Mark end of experimental phase. No changes from last version.
+
 ## [0.6.3] - 2025-10-30
 - Pin onnxruntime on Windows ([#1099](https://github.com/google/magika/pull/1099)).
 - Add docstrings for all relevant modules, classes, and methods.
-- Improved READMEs and overall documentation.
+- Improved READMEs and overall [documentation](https://securityresearch.google/magika/cli-and-bindings/python/).
 
 ## [0.6.2] - 2025-05-02
 

--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -15,7 +15,7 @@
 # ruff: noqa: D104
 
 
-__version__ = "0.6.3"
+__version__ = "1.0.1"
 
 
 import dotenv


### PR DESCRIPTION
We skip 1.0.0 due to #1213.