### PR TITLE
python: pin maturin version to deal with potential regression

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -67,7 +67,7 @@ dev-dependencies = [
 ]
 
 [build-system]
-requires = ["maturin>=1.7,<=1.10.2"]
+requires = ["maturin>=1.7,<=1.10.2"] # Pinned to avoid a potential regression in newer versions.
 build-backend = "maturin"
 
 [tool.hatch.version]


### PR DESCRIPTION
Something has changed in the latest versions of maturin (from 1.11.2 on January 5th 2026), and this caused our build pipelines to fail since then. Specifically, before these recent versions, something like this would work:
```
$ uv sync
[...]
$ uv run magika -V
magika 1.0.2-dev standard_v3_3
```

With the latest versions, we get the following error:
```
$ uv run magika -V
error: Failed to spawn: `magika`
  Caused by: No such file or directory (os error 2)
```

Also, the latest maturin's version outputs the magika's rust binary in the following directory: `/python/src/magika-1.0.3.dev0.data/scripts/magika`.

As a workaround, we pin the builder to an older version of maturin. We'll remove the pin once we figure out what's going on with the maturin folks.