### PR TITLE
web: add Homebrew install option to CLI installation tabs

### DIFF
--- a/website-ng/src/content/docs/getting-started/installation.mdx
+++ b/website-ng/src/content/docs/getting-started/installation.mdx
@@ -29,6 +29,11 @@ If you intend to use Magika only as a command line, you can install it in a numb
   powershell -ExecutionPolicy Bypass -c "irm https://securityresearch.google/magika/install.ps1 | iex"
   ```
   </TabItem>
+  <TabItem label="brew">
+  ```shell
+  brew install magika
+  ```
+  </TabItem>
 </Tabs>
 
 


### PR DESCRIPTION
Fixes #1245 

This PR adds brew installation instructions to `/getting-started/installation/` page of the website. 

Current version lacks brew instructions: https://securityresearch.google/magika/getting-started/installation/