### PR TITLE
python: remove direct dependency on numpy

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -11,6 +11,7 @@ semver guidelines for more details about this.
 
 ## [Unreleased]
 - Mark python 3.14 as supported.
+- Remove direct dependency on numpy.
 
 ## [1.0.1] - 2025-10-31
 - Mark end of experimental phase. No changes from last version.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,10 +51,6 @@ dependencies = [
     # Windows-specific cap for older Python versions (Ensure this is intentional!)
     "onnxruntime<=1.20.1 ; sys_platform == 'win32' and python_version < '3.13'",
 
-    "numpy>=1.24; python_version < '3.12'",
-    "numpy>=1.26; python_version >= '3.12' and python_version < '3.13'",
-    "numpy>=2.1.0; python_version >= '3.13' and python_version < '3.14'",
-    "numpy>=2.3.3; python_version >= '3.14'",
     "python-dotenv>=1.0.1",
 ]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -542,10 +542,6 @@ version = "1.0.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "numpy", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or (python_full_version >= '3.10' and python_full_version < '3.12')" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*' or python_full_version == '3.12.*'" },
-    { name = "numpy", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "onnxruntime", version = "1.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -570,10 +566,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
-    { name = "numpy", marker = "python_full_version < '3.12'", specifier = ">=1.24" },
-    { name = "numpy", marker = "python_full_version == '3.12.*'", specifier = ">=1.26" },
-    { name = "numpy", marker = "python_full_version == '3.13.*'", specifier = ">=2.1.0" },
-    { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.3" },
     { name = "onnxruntime", marker = "python_full_version < '3.10'", specifier = ">=1.17.0,<1.20.0" },
     { name = "onnxruntime", marker = "python_full_version == '3.10.*'", specifier = ">=1.17.0,<1.24.1" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and python_full_version < '3.13'", specifier = ">=1.17.0" },


### PR DESCRIPTION
Fixes #1268.

There don't seem to be performance regressions. The mean inference time and other metrics are relatively noisy, but there doesn't seem to be a big change. Cherrypicked examples below.

Stats with `numpy` (old version):
```
Inference stats over 770 files (repeat=10):
  Min: 0.0730 ms
  Max: 12.0421 ms
  Mean: 5.2871 ms
  Median: 5.2845 ms
  Total: 4071.0329 ms
```


Stats without `numpy` (this new version):
```
Inference stats over 770 files (repeat=10):
  Min: 0.0687 ms
  Max: 10.6079 ms
  Mean: 5.2051 ms
  Median: 5.2412 ms
  Total: 4007.9172 ms
```