### PR TITLE
python: remove dependency to python-dotenv

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,8 +10,9 @@ should be considered as a major (and thus potentially breaking) change. See
 semver guidelines for more details about this.
 
 ## [Unreleased]
-- Mark python 3.14 as supported.
-- Remove direct dependency on numpy.
+- Mark Python 3.14 as supported.
+- Remove direct dependency on NumPy.
+- Remove dependency on python-dotenv (note: .env files are no longer loaded automatically).
 
 ## [1.0.1] - 2025-10-31
 - Mark end of experimental phase. No changes from last version.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,8 +50,6 @@ dependencies = [
 
     # Windows-specific cap for older Python versions (Ensure this is intentional!)
     "onnxruntime<=1.20.1 ; sys_platform == 'win32' and python_version < '3.13'",
-
-    "python-dotenv>=1.0.1",
 ]
 
 

--- a/python/src/magika/__init__.py
+++ b/python/src/magika/__init__.py
@@ -17,8 +17,6 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-import dotenv
-
 from magika.magika import Magika
 from magika.types.content_type_info import ContentTypeInfo
 from magika.types.content_type_label import ContentTypeLabel
@@ -46,5 +44,3 @@ __all__ = [
     "PredictionMode",
     "Status",
 ]
-
-dotenv.load_dotenv(dotenv.find_dotenv())

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -545,7 +545,6 @@ dependencies = [
     { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "onnxruntime", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "onnxruntime", version = "1.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "python-dotenv" },
 ]
 
 [package.dev-dependencies]
@@ -572,7 +571,6 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version == '3.13.*'", specifier = ">=1.21.0" },
     { name = "onnxruntime", marker = "python_full_version >= '3.14'", specifier = ">=1.24.1" },
     { name = "onnxruntime", marker = "python_full_version < '3.13' and sys_platform == 'win32'", specifier = "<=1.20.1" },
-    { name = "python-dotenv", specifier = ">=1.0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -1229,15 +1227,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/8c/9862305bdcd6020bc7b45b1b5e7397a6caf1a33d3025b9a003b39075ffb2/pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce", size = 1439314, upload-time = "2024-07-25T10:40:00.159Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/f9/cf155cf32ca7d6fa3601bc4c5dd19086af4b320b706919d48a4c79081cf9/pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5", size = 341802, upload-time = "2024-07-25T10:39:57.834Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This also avoids loading .env, which may surprise some users. Only the magika_client.py was using the environment to override the default model used, so I don't expect this to create backward compatibility problems.

Fixes #1283.