### PR TITLE
Remove x86_64-apple-darwin from supported CLI

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -35,5 +35,4 @@ global = "ubuntu-latest"
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
 x86_64-unknown-linux-gnu = "ubuntu-latest"
 aarch64-apple-darwin = "macos-latest"
-x86_64-apple-darwin = "macos-13"
 x86_64-pc-windows-msvc = "windows-latest"


### PR DESCRIPTION
The macos-13 runner does not exist anymore. See https://github.com/google/magika/actions/runs/22388421835/job/64804151009 for the release failure.

After merge, I'll recreate the tag to trigger the release again.