### PR TITLE
Fix: use DARK_GRAY for unmapped content type groups in CLI output (fixes #1243)

### DIFF
--- a/python/src/magika/cli/magika_client.py
+++ b/python/src/magika/cli/magika_client.py
@@ -255,6 +255,8 @@ def main(
         "image": colors.YELLOW,
         "video": colors.YELLOW,
         "code": colors.LIGHT_BLUE,
+        "text": colors.DARK_GRAY,
+        "unknown": colors.DARK_GRAY,
     }
 
     # updated only when we need to output in JSON format
@@ -309,7 +311,7 @@ def main(
 
                     if with_colors:
                         start_color = color_by_group.get(
-                            result.prediction.output.group, colors.WHITE
+                            result.prediction.output.group, colors.DARK_GRAY
                         )
                         end_color = colors.RESET
                 else:

--- a/python/tests/test_python_magika_client.py
+++ b/python/tests/test_python_magika_client.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import subprocess
+import tempfile
 from pathlib import Path
+
+from magika import colors
 
 
 def test_python_magika_client() -> None:
@@ -29,3 +32,46 @@ def test_python_magika_client() -> None:
     # quick test to check there are no crashes
     cmd = [str(python_magika_client_path), str(python_magika_client_path)]
     subprocess.run(cmd, capture_output=True, check=True)
+
+
+def test_colored_output_visible_on_light_background_terminals() -> None:
+    """Regression test for https://github.com/google/magika/issues/1243.
+
+    The fallback color for content type groups not explicitly mapped in
+    color_by_group must not be bright white (\033[1;37m), which is nearly
+    invisible on light-background terminals. DARK_GRAY (\033[1;30m) is
+    visible on both dark and light backgrounds.
+    """
+    python_root_dir = Path(__file__).parent.parent
+    python_magika_client_path = (
+        python_root_dir / "src" / "magika" / "cli" / "magika_client.py"
+    ).resolve()
+
+    # Write a plain text file — classified as group="text", which previously
+    # fell through to the bright-white fallback color.
+    with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tmp:
+        tmp.write("Hello, world!\n")
+        tmp_path = Path(tmp.name)
+
+    try:
+        result = subprocess.run(
+            [str(python_magika_client_path), "--colors", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        output = result.stdout
+        # The output must not contain the bright-white ANSI code, which is
+        # invisible on white/light-background terminals.
+        assert colors.WHITE not in output, (
+            f"Output used bright-white ({repr(colors.WHITE)}), which is "
+            "invisible on light-background terminals. Use DARK_GRAY instead."
+        )
+        # DARK_GRAY must be present so that content types in the "text" group
+        # (and any other unmapped group) are readable on light terminals.
+        assert colors.DARK_GRAY in output, (
+            f"Expected DARK_GRAY ({repr(colors.DARK_GRAY)}) in colored output "
+            "for a plain-text file, but it was not found."
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/python/tests/test_python_magika_client.py
+++ b/python/tests/test_python_magika_client.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import subprocess
-import tempfile
 from pathlib import Path
 
 from magika import colors
@@ -34,7 +33,9 @@ def test_python_magika_client() -> None:
     subprocess.run(cmd, capture_output=True, check=True)
 
 
-def test_colored_output_visible_on_light_background_terminals() -> None:
+def test_colored_output_visible_on_light_background_terminals(
+    tmp_path: Path,
+) -> None:
     """Regression test for https://github.com/google/magika/issues/1243.
 
     The fallback color for content type groups not explicitly mapped in
@@ -49,29 +50,25 @@ def test_colored_output_visible_on_light_background_terminals() -> None:
 
     # Write a plain text file — classified as group="text", which previously
     # fell through to the bright-white fallback color.
-    with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tmp:
-        tmp.write("Hello, world!\n")
-        tmp_path = Path(tmp.name)
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("Hello, world!\n")
 
-    try:
-        result = subprocess.run(
-            [str(python_magika_client_path), "--colors", str(tmp_path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        output = result.stdout
-        # The output must not contain the bright-white ANSI code, which is
-        # invisible on white/light-background terminals.
-        assert colors.WHITE not in output, (
-            f"Output used bright-white ({repr(colors.WHITE)}), which is "
-            "invisible on light-background terminals. Use DARK_GRAY instead."
-        )
-        # DARK_GRAY must be present so that content types in the "text" group
-        # (and any other unmapped group) are readable on light terminals.
-        assert colors.DARK_GRAY in output, (
-            f"Expected DARK_GRAY ({repr(colors.DARK_GRAY)}) in colored output "
-            "for a plain-text file, but it was not found."
-        )
-    finally:
-        tmp_path.unlink(missing_ok=True)
+    result = subprocess.run(
+        [str(python_magika_client_path), "--colors", str(test_file)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout
+    # The output must not contain the bright-white ANSI code, which is
+    # invisible on white/light-background terminals.
+    assert colors.WHITE not in output, (
+        f"Output used bright-white ({repr(colors.WHITE)}), which is "
+        "invisible on light-background terminals. Use DARK_GRAY instead."
+    )
+    # DARK_GRAY must be present so that content types in the "text" group
+    # (and any other unmapped group) are readable on light terminals.
+    assert colors.DARK_GRAY in output, (
+        f"Expected DARK_GRAY ({repr(colors.DARK_GRAY)}) in colored output "
+        "for a plain-text file, but it was not found."
+    )


### PR DESCRIPTION
## Summary

Fixes #1243.

The Python CLI's colored output was nearly invisible on light-background terminals because content type groups not explicitly listed in `color_by_group` (including `"text"`, `"unknown"`, `"application"`, `"font"`, `"inode"`) all fell back to `colors.WHITE` (`\033[1;37m` — bright white), which disappears on white terminal backgrounds.

---

## Root Cause

In `magika_client.py:L312`, `color_by_group.get(group, colors.WHITE)` was used to select the ANSI color. The dict covered 7 groups but the model has 12, so 5 groups — including the common `"text"` and `"unknown"` — silently fell back to bright white. On a light-background terminal, this produces output that looks like light gray at best and invisible at worst.

---

## Solution

Two targeted changes in `python/src/magika/cli/magika_client.py`:

1. **Add explicit entries** for `"text"` and `"unknown"` in `color_by_group`, both mapped to `colors.DARK_GRAY`.
2. **Change the dict fallback** from `colors.WHITE` to `colors.DARK_GRAY` so any future unmapped groups also display visibly.

`DARK_GRAY` (`\033[1;30m` — bold/bright black) renders as dark gray on light terminals (clearly visible on white) and as dark gray on dark terminals (readable, appropriate for lower-confidence output). This matches the approach suggested in the issue: _"Darkening the gray should solve the problem nicely, without being too hard to see on a dark background."_

---

## Testing

- Added `test_colored_output_visible_on_light_background_terminals` in `python/tests/test_python_magika_client.py` — reproduces the exact scenario from the issue: runs the CLI with `--colors` on a plain `.txt` file (classified as `group="text"`), asserts the output contains `DARK_GRAY` and does **not** contain `WHITE`.
- All 32 existing tests continue to pass (`uv run pytest tests -m "not slow"`)
- `ruff check`, `ruff format`, and `mypy` all pass clean

---

## Checklist

- [x] Fixes the root cause (bright-white fallback replaced with dark gray)
- [x] New test covers the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions (ruff + mypy clean)
- [x] Read CONTRIBUTING.md