### PR TITLE
feat: add Magika.get_content_type_info() public API method (fixes #826)

### DIFF
--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -272,13 +272,14 @@ class Magika:
 
         Raises:
             MagikaError: If the label is not present in the content type
-                knowledge base (e.g., ContentTypeLabel.UNDEFINED).
+                knowledge base.
         """
-        if label not in self._cts_infos:
+        try:
+            return self._cts_infos[label]
+        except KeyError:
             raise MagikaError(
                 f"Content type '{label}' is not in the content type knowledge base."
-            )
-        return self._cts_infos[label]
+            ) from None
 
     @staticmethod
     def _get_default_model_name() -> str:

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -256,6 +256,30 @@ class Magika:
         model_content_types.update(self._model_config.target_labels_space)
         return sorted(model_content_types)
 
+    def get_content_type_info(self, label: ContentTypeLabel) -> ContentTypeInfo:
+        """Returns metadata for a given content type label.
+
+        This provides access to the content type knowledge base, exposing
+        structured metadata such as mime type, group, human-readable
+        description, common file extensions, and whether the type is
+        text-based.
+
+        Args:
+            label: The ContentTypeLabel to look up.
+
+        Returns:
+            The ContentTypeInfo for the given label.
+
+        Raises:
+            MagikaError: If the label is not present in the content type
+                knowledge base (e.g., ContentTypeLabel.UNDEFINED).
+        """
+        if label not in self._cts_infos:
+            raise MagikaError(
+                f"Content type '{label}' is not in the content type knowledge base."
+            )
+        return self._cts_infos[label]
+
     @staticmethod
     def _get_default_model_name() -> str:
         """Returns the default model name.

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -761,6 +761,37 @@ def test_get_model_and_output_content_types() -> None:
     }.issubset(model_content_types_set)
 
 
+def test_get_content_type_info() -> None:
+    """Test Magika.get_content_type_info() — fixes #826.
+
+    Verifies that the public API correctly exposes ContentTypeInfo metadata
+    (mime_type, group, description, extensions, is_text) for every
+    ContentTypeLabel that is part of the content type knowledge base.
+    """
+    m = Magika()
+
+    # Every output content type must be queryable and return valid metadata.
+    for label in m.get_output_content_types():
+        info = m.get_content_type_info(label)
+        assert isinstance(info, ContentTypeInfo)
+        assert info.label == label
+        assert isinstance(info.mime_type, str) and info.mime_type != ""
+        assert isinstance(info.group, str) and info.group != ""
+        assert isinstance(info.description, str) and info.description != ""
+        assert isinstance(info.extensions, list)
+        assert isinstance(info.is_text, bool)
+
+    # Spot-check a well-known content type's metadata.
+    pdf_info = m.get_content_type_info(ContentTypeLabel.PDF)
+    assert pdf_info.mime_type == "application/pdf"
+    assert pdf_info.group == "document"
+    assert pdf_info.is_text is False
+
+    # Text-based type should report is_text=True.
+    py_info = m.get_content_type_info(ContentTypeLabel.PYTHON)
+    assert py_info.is_text is True
+
+
 def test_magika_imports():
     imported_modules = utils.get_imported_objects_after_wildcard()
 

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional
 
 import pytest
 
-from magika import Magika, PredictionMode
+from magika import Magika, MagikaError, PredictionMode
 from magika.types import (
     ContentTypeInfo,
     ContentTypeLabel,
@@ -790,6 +790,10 @@ def test_get_content_type_info() -> None:
     # Text-based type should report is_text=True.
     py_info = m.get_content_type_info(ContentTypeLabel.PYTHON)
     assert py_info.is_text is True
+
+    # An unknown label must raise MagikaError.
+    with pytest.raises(MagikaError, match="is not in the content type knowledge base"):
+        m.get_content_type_info("this_is_not_a_real_label")  # type: ignore[arg-type]
 
 
 def test_magika_imports():


### PR DESCRIPTION
## Summary

Fixes #826.

The content type knowledge base (mime type, group, description, extensions, is_text) was only accessible via the private `_get_ct_info()` method and the internal `_cts_infos` dict. This PR exposes a public `get_content_type_info(label)` method, completing the content-type introspection API alongside the existing `get_output_content_types()` and `get_model_content_types()` methods.

---

## Root Cause

`Magika._get_ct_info()` at `magika.py:344` held all the content type metadata but was private and undocumented. External clients had no supported way to query mime type, group, description, or file extensions for a given `ContentTypeLabel`.

---

## Solution

Added `Magika.get_content_type_info(label: ContentTypeLabel) -> ContentTypeInfo` in `python/src/magika/magika.py`. The method:
- Returns the `ContentTypeInfo` for any label present in the knowledge base
- Raises `MagikaError` (rather than a bare `KeyError`) if the label is not in the KB, giving callers a clear error message
- Is a thin, clean wrapper around the existing `_cts_infos` dict — no new state introduced

The method fits naturally alongside `get_output_content_types()` and `get_model_content_types()`: those methods answer *"which labels exist?"* while `get_content_type_info()` answers *"what does this label mean?"*

---

## Testing

- Added `test_get_content_type_info` in `python/tests/test_magika_python_module.py` that:
  - Calls `get_content_type_info()` for every label returned by `get_output_content_types()` and asserts all fields are valid
  - Spot-checks `ContentTypeLabel.PDF` for exact expected values (`application/pdf`, group `document`, `is_text=False`)
  - Verifies `ContentTypeLabel.PYTHON` returns `is_text=True`
- All 33 existing tests pass: `uv run pytest tests -m "not slow"`
- `ruff check`, `ruff format`, and `mypy` pass clean

---

## Checklist

- [x] Fixes the root cause (private method exposed via clean public API)
- [x] New test covers all output content types and spot-checks specific metadata
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md