### PR TITLE
fix(website): redirect /magika/ to introduction/overview

### DIFF
--- a/website-ng/src/content/docs/index.mdx
+++ b/website-ng/src/content/docs/index.mdx
@@ -1,5 +1,0 @@
----
-title: Magika
-description: Magika landing page
-template: splash
----


### PR DESCRIPTION
Removes the empty index.mdx splash page that was silently blocking Astro's [redirect config](https://github.com/ashmod/magika/blob/6008c52b7ea3c4927c6e9c68b978012e2b0a5ef2/website-ng/astro.config.mjs#L147), causing /magika/ to render a blank page instead of redirecting to /magika/introduction/overview/.

Fixes #1331