### PR TITLE
fix(magika): prevent whitespace-prefix bypass in fallback detection path

### DIFF
--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -757,10 +757,41 @@ class Magika:
                 == self._model_config.padding_token
             ):
                 # If the n-th token is padding, then it means that,
-                # post-stripping, we do not have enough meaningful
-                # bytes.
-                bytes_to_read = min(seekable.size, self._model_config.block_size)
-                content = seekable.read_at(0, bytes_to_read)
+                # post-stripping, we do not have enough meaningful bytes
+                # in the first block.
+                #
+                # Security note: this path is also reachable when an attacker
+                # prepends ≥block_size bytes of ASCII whitespace to a binary
+                # payload (e.g. ELF, PE, PHP webshell).  In that scenario,
+                # re-reading the same first block (all whitespace) and feeding
+                # it to _get_result_from_few_bytes would return TXT, because
+                # the UTF-8 check passes for whitespace — completely ignoring
+                # the actual payload hidden beyond offset block_size.
+                #
+                # To prevent this bypass we strip the leading whitespace from
+                # the first block.  If the result is empty (i.e. the entire
+                # first block was whitespace) *and* the seekable has content
+                # beyond block_size, we advance past the whitespace prefix and
+                # read the next block, which contains the actual payload.
+                first_block = seekable.read_at(
+                    0, min(seekable.size, self._model_config.block_size)
+                )
+                stripped_first_block = first_block.lstrip()
+
+                if (
+                    len(stripped_first_block) == 0
+                    and seekable.size > self._model_config.block_size
+                ):
+                    # The entire first block was whitespace.  Read the next
+                    # block to examine the actual non-whitespace content.
+                    payload_offset = self._model_config.block_size
+                    bytes_to_read = min(
+                        seekable.size - payload_offset, self._model_config.block_size
+                    )
+                    content = seekable.read_at(payload_offset, bytes_to_read)
+                else:
+                    content = first_block
+
                 result = self._get_result_from_few_bytes(content, path=path)
                 return result, None
 

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -299,6 +299,69 @@ def test_magika_module_with_whitespaces() -> None:
             )
 
 
+def test_magika_module_whitespace_prefix_does_not_bypass_binary_detection() -> None:
+    """Regression test for the whitespace-padding bypass.
+
+    An attacker can prepend >= block_size bytes of ASCII whitespace to any
+    binary payload.  Before the fix, lstrip() on the first block produced an
+    empty buffer, which caused the fallback path to re-read the same whitespace
+    block, decode it as valid UTF-8, and return ContentTypeLabel.TXT for
+    arbitrary binary content — effectively bypassing file-type detection.
+
+    After the fix, when the entire first block is whitespace but more content
+    exists beyond it, Magika advances past the whitespace and inspects the
+    actual payload block, correctly identifying the binary content.
+    """
+    m = Magika(prediction_mode=PredictionMode.BEST_GUESS)
+
+    block_size = m._model_config.block_size
+    # A prefix of exactly block_size whitespace bytes forces the bypass path.
+    ws_prefix = b" " * block_size
+
+    # Binary payloads that must NOT be classified as TXT after the prefix.
+    # We use the raw magic bytes / headers that are unambiguously non-text.
+    binary_payloads = [
+        # ELF header (Linux binary)
+        b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 200,
+        # PE/MZ header (Windows executable)
+        b"MZ\x90\x00\x03\x00\x00\x00\x04\x00\x00\x00" + b"\x00" * 100,
+        # Generic non-UTF-8 binary bytes
+        b"\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f"
+        * 64,
+    ]
+
+    for payload in binary_payloads:
+        crafted = ws_prefix + payload
+
+        # Verify via bytes interface
+        res = m.identify_bytes(crafted)
+        assert res.ok
+        assert res.output.label != ContentTypeLabel.TXT, (
+            f"Bypass detected via identify_bytes: "
+            f"payload starting with {payload[:8]!r} was misclassified as TXT"
+        )
+
+        # Verify via stream interface
+        res = m.identify_stream(io.BytesIO(crafted))
+        assert res.ok
+        assert res.output.label != ContentTypeLabel.TXT, (
+            f"Bypass detected via identify_stream: "
+            f"payload starting with {payload[:8]!r} was misclassified as TXT"
+        )
+
+        # Verify via path interface
+        with tempfile.TemporaryDirectory() as td:
+            tf_path = Path(td) / "crafted.bin"
+            tf_path.write_bytes(crafted)
+            res = m.identify_path(tf_path)
+            assert res.ok
+            assert res.output.label != ContentTypeLabel.TXT, (
+                f"Bypass detected via identify_path: "
+                f"payload starting with {payload[:8]!r} was misclassified as TXT"
+            )
+
+
+
 def test_magika_module_with_different_prediction_modes() -> None:
     model_dir = utils.get_default_model_dir()
     m = Magika(model_dir=model_dir, prediction_mode=PredictionMode.BEST_GUESS)


### PR DESCRIPTION
When a file has >= block_size bytes of leading ASCII whitespace followed by a binary payload, the existing fallback path misclassified the file as 'txt'. The root cause was a two-step failure:

1. _extract_features_from_seekable reads block_size (4096) bytes and calls lstrip(), producing an empty buffer if all bytes are whitespace. This fills beg[] with all padding_token values.

2. _get_result_or_features_from_seekable detects the all-padding condition and falls back to _get_result_from_few_bytes. However, it re-read the *same* first block_size bytes (still all whitespace), passed them to _get_label_from_few_bytes, which only checks UTF-8 validity. Whitespace is valid UTF-8, so the method returned ContentTypeLabel.TXT — ignoring the actual payload hidden beyond byte 4096.

Fix: In the fallback path, strip the leading whitespace from the first block. If the result is empty *and* the seekable has content beyond block_size, advance past the whitespace prefix and read the next block (which contains the actual payload) before calling _get_result_from_few_bytes.

This preserves the existing behaviour for:
- Legitimate files that are shorter than block_size (no change).
- Files with *some* leading whitespace that does not fill the entire first block (stripped_first_block is non-empty; existing path taken).
- Files whose entire content is whitespace (seekable.size <= block_size; the bypass condition is not triggered).

Only files where ALL of the first block_size bytes are whitespace AND more content follows are now routed to the new payload-reading path.

Regression test added:
test_magika_module_whitespace_prefix_does_not_bypass_binary_detection verifies ELF, PE/MZ, and non-UTF-8 binary payloads are not classified as TXT when prepended with block_size whitespace bytes.