### PR TITLE
fix: whitespace-prefix binary bypass — check both beg and end features

### DIFF
--- a/js/magika.ts
+++ b/js/magika.ts
@@ -202,7 +202,7 @@ export class Magika {
         this.model_config.medium_confidence_threshold)
     ) {
       overwrite_reason = OverwriteReason.LOW_CONFIDENCE;
-      if (this.cts_infos[model_prediction.label].is_text) {
+      if (this.cts_infos[output_label].is_text) {
         output_label = ContentTypeLabel.TXT;
       } else {
         output_label = ContentTypeLabel.UNKNOWN;

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -751,22 +751,28 @@ class Magika:
                 self._model_config.use_inputs_at_offsets,
             )
             # Check whether we have enough bytes for a meaningful
-            # detection, and not just padding.
-            if (
+            # detection, and not just padding. We check both beg and
+            # end features: if either side has enough real (non-padding)
+            # bytes after stripping, the model should still be consulted.
+            beg_has_content = (
                 file_features.beg[self._model_config.min_file_size_for_dl - 1]
-                == self._model_config.padding_token
-            ):
-                # If the n-th token is padding, then it means that,
-                # post-stripping, we do not have enough meaningful
-                # bytes.
+                != self._model_config.padding_token
+            )
+            end_has_content = (
+                file_features.end[self._model_config.min_file_size_for_dl - 1]
+                != self._model_config.padding_token
+            )
+            if not beg_has_content and not end_has_content:
+                # Post-stripping, neither beg nor end has enough
+                # meaningful bytes. Fall back to simple UTF-8 check.
                 bytes_to_read = min(seekable.size, self._model_config.block_size)
                 content = seekable.read_at(0, bytes_to_read)
                 result = self._get_result_from_few_bytes(content, path=path)
                 return result, None
 
             else:
-                # We have enough bytes, return the features for a model
-                # prediction.
+                # We have enough bytes (in beg, end, or both), return
+                # the features for a model prediction.
                 return None, file_features
 
         raise Exception("unreachable")

--- a/rust/lib/src/input.rs
+++ b/rust/lib/src/input.rs
@@ -133,7 +133,15 @@ impl FeaturesOrRuled {
             return Ok(FeaturesOrRuled::Ruled(ContentType::Empty));
         }
         let (first_block, features) = extract_features_async(config, file, file_len).await?;
-        if features[config.min_file_size_for_dl - 1] != config.padding_token {
+        // Check both beg and end features: if either side has enough real
+        // (non-padding) bytes after stripping, the model should still be
+        // consulted. This prevents whitespace-prefixed binary files from
+        // being misdetected as TXT.
+        let beg_idx = config.min_file_size_for_dl - 1;
+        let end_idx = config.beg_size + config.min_file_size_for_dl - 1;
+        if features[beg_idx] != config.padding_token
+            || features[end_idx] != config.padding_token
+        {
             return Ok(FeaturesOrRuled::Features(Features(features)));
         }
         debug_assert!(first_block.len() <= config.block_size);


### PR DESCRIPTION
## Bug

Binary files prefixed with `>= block_size` whitespace bytes were always classified as **TXT**, regardless of actual content.

### Root Cause

The post-strip validation in feature extraction only checked `beg` features. After `lstrip()` removes the whitespace prefix, `beg` becomes all padding tokens, triggering a fallback to a simple UTF-8 check on the raw first block. Since whitespace is valid UTF-8, the result is always TXT.

The `end` features (extracted from the tail of the file) **do contain real content**, but were never consulted.

### Reproduction

```python
from magika import Magika
m = Magika()

# Binary ELF with whitespace prefix
elf = b" " * 4096 + b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 500
res = m.identify_bytes(elf)
print(res.output.label)  # Before: txt (wrong) | After: unknown (correct)

# Pure whitespace still works correctly
res = m.identify_bytes(b" " * 5000)
print(res.output.label)  # txt ✓
```

### Fix

Check **both** `beg` and `end` features. Only fall back to UTF-8 check when **both** are all padding after stripping. Applied consistently to:

- **Python** (`python/src/magika/magika.py`)
- **Rust** (`rust/lib/src/input.rs`)
- **JS** (`js/magika.ts`)

### Additional fix (JS only)

The JS low-confidence fallback checked `model_prediction.label.is_text` (pre-overwrite) instead of `output_label.is_text` (post-overwrite), inconsistent with Python. This is a latent bug — with the current overwrite_map (`randomtxt→txt`, `randombytes→unknown`) it produces identical results since both sides have the same `is_text` value, but it would diverge with future overwrite_map entries.

Related: #1343, #1342