### PR TITLE
fix(website): improve progress percentage contrast in dark mode

### DIFF
--- a/website-ng/src/lib/components/ui/progress/progress.svelte
+++ b/website-ng/src/lib/components/ui/progress/progress.svelte
@@ -44,7 +44,7 @@
   ></div>
   {#if showPercentage}
     <div
-      class="absolute inset-0 flex mt-0-important font-size sl-markdown-content items-center justify-center text-xs font-medium text-foreground z-10 text-2xl mix-blend-difference text-white"
+      class="absolute inset-0 z-10 mt-0-important flex items-center justify-center sl-markdown-content text-2xl text-xs font-medium text-white [text-shadow:0_1px_2px_rgb(0_0_0_/_0.75)]"
     >
       {percentage}%
     </div>


### PR DESCRIPTION
## Summary
- improve the score percentage text contrast in the website-ng progress component
- remove conflicting utility classes (	ext-foreground, mix-blend-difference) that can make the percentage unreadable on dark backgrounds
- keep percentage text white and add a subtle text-shadow for reliable readability

## Motivation
Fixes #681.

## Testing
- Not run (UI-only CSS class change in website-ng; local dependencies were not installed in this automation run).