### PR TITLE
python: detect armored PGP public keys on .asc paths

### DIFF
--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -226,6 +226,7 @@ class Magika:
         output_content_types: Set[ContentTypeLabel] = {
             ContentTypeLabel.DIRECTORY,
             ContentTypeLabel.EMPTY,
+            ContentTypeLabel.PGP,
             ContentTypeLabel.SYMLINK,
             ContentTypeLabel.TXT,
             ContentTypeLabel.UNKNOWN,
@@ -399,6 +400,19 @@ class Magika:
             return result
         assert features is not None
         return self._get_results_from_features([(Path("-"), features)])["-"]
+
+    @staticmethod
+    def _get_label_from_path_and_content_prefix(
+        path: Path, content: bytes
+    ) -> Optional[ContentTypeLabel]:
+        if path.suffix.lower() != ".asc":
+            return None
+
+        stripped_content = content.lstrip()
+        if stripped_content.startswith(b"-----BEGIN PGP PUBLIC KEY BLOCK-----"):
+            return ContentTypeLabel.PGP
+
+        return None
 
     @staticmethod
     def _extract_features_from_seekable(
@@ -735,41 +749,48 @@ class Magika:
             )
             return result, None
 
-        elif seekable.size < self._model_config.min_file_size_for_dl:
+        bytes_to_read = min(seekable.size, self._model_config.block_size)
+        label = self._get_label_from_path_and_content_prefix(
+            path, seekable.read_at(0, bytes_to_read)
+        )
+        if label is not None:
+            result = self._get_result_from_labels_and_score(
+                path=path,
+                dl_label=ContentTypeLabel.UNDEFINED,
+                output_label=label,
+                score=1.0,
+            )
+            return result, None
+
+        if seekable.size < self._model_config.min_file_size_for_dl:
             content = seekable.read_at(0, seekable.size)
             result = self._get_result_from_few_bytes(content, path=path)
             return result, None
 
-        else:
-            file_features = Magika._extract_features_from_seekable(
-                seekable,
-                self._model_config.beg_size,
-                self._model_config.mid_size,
-                self._model_config.end_size,
-                self._model_config.padding_token,
-                self._model_config.block_size,
-                self._model_config.use_inputs_at_offsets,
-            )
-            # Check whether we have enough bytes for a meaningful
-            # detection, and not just padding.
-            if (
-                file_features.beg[self._model_config.min_file_size_for_dl - 1]
-                == self._model_config.padding_token
-            ):
-                # If the n-th token is padding, then it means that,
-                # post-stripping, we do not have enough meaningful
-                # bytes.
-                bytes_to_read = min(seekable.size, self._model_config.block_size)
-                content = seekable.read_at(0, bytes_to_read)
-                result = self._get_result_from_few_bytes(content, path=path)
-                return result, None
+        file_features = Magika._extract_features_from_seekable(
+            seekable,
+            self._model_config.beg_size,
+            self._model_config.mid_size,
+            self._model_config.end_size,
+            self._model_config.padding_token,
+            self._model_config.block_size,
+            self._model_config.use_inputs_at_offsets,
+        )
+        # Check whether we have enough bytes for a meaningful
+        # detection, and not just padding.
+        if (
+            file_features.beg[self._model_config.min_file_size_for_dl - 1]
+            == self._model_config.padding_token
+        ):
+            # If the n-th token is padding, then it means that,
+            # post-stripping, we do not have enough meaningful
+            # bytes.
+            content = seekable.read_at(0, bytes_to_read)
+            result = self._get_result_from_few_bytes(content, path=path)
+            return result, None
 
-            else:
-                # We have enough bytes, return the features for a model
-                # prediction.
-                return None, file_features
-
-        raise Exception("unreachable")
+        # We have enough bytes, return the features for a model prediction.
+        return None, file_features
 
     def _get_result_from_few_bytes(
         self, content: bytes, path: Path = Path("-")

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -205,6 +205,23 @@ def test_magika_module_with_short_content() -> None:
             assert res.prediction.score == 1.0
 
 
+def test_magika_module_with_ascii_armored_pgp_key_path() -> None:
+    source_path = utils.get_basic_tests_files_dir() / "pem" / "doc.pem"
+
+    with tempfile.TemporaryDirectory() as td:
+        tf_path = Path(td) / "mullvad-code-signing.asc"
+        tf_path.write_bytes(source_path.read_bytes())
+
+        m = Magika()
+        res = m.identify_path(tf_path)
+
+        assert res.path == tf_path
+        assert res.ok
+        assert res.prediction.dl.label == ContentTypeLabel.UNDEFINED
+        assert res.prediction.output.label == ContentTypeLabel.PGP
+        assert res.prediction.score == 1.0
+
+
 def test_magika_module_with_python_and_non_python_content() -> None:
     python_content = (
         b"import flask\nimport requests\n\ndef foo(a):\n    print(f'Test {a}')\n"
@@ -465,6 +482,11 @@ def test_magika_module_overwrite_reason() -> None:
         assert m_medium._get_output_label_from_dl_label_and_score(
             generic_ct, medium_confidence_threshold - 0.01
         ) == (generic_ct, OverwriteReason.NONE)
+
+
+def test_magika_module_output_content_types_include_path_based_pgp() -> None:
+    m = Magika()
+    assert ContentTypeLabel.PGP in m.get_output_content_types()
 
 
 def test_magika_module_with_directory() -> None:


### PR DESCRIPTION
Closes #1338.

## Summary
- short-circuit `.asc` files that start with `-----BEGIN PGP PUBLIC KEY BLOCK-----` to `pgp`
- include that path-based result in `get_output_content_types()`
- add regression coverage for the `.asc` path case

## Testing
- `uv run -- pytest tests/test_magika_python_module.py -k "ascii_armored_pgp_key_path or output_content_types_include_path_based_pgp"`
- `uv run -- pytest tests/test_magika_python_module.py -k "not with_symlink and not with_permission_error and not with_big_file"`