### PR TITLE
docs: link stable binding versions to release tags

### DIFF
--- a/python/scripts/check_documentation.py
+++ b/python/scripts/check_documentation.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import re
+from urllib.parse import quote
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -79,12 +80,32 @@ def check_versions_are_up_to_date() -> bool:
     demo_model_name = get_demo_model_name()
 
     expected_table = [
-        (rust_cli_latest_stable_version, rust_default_model_name),
-        (python_latest_stable_version, python_default_model_name),
-        (javascript_latest_stable_version, javascript_default_model_name),
-        (rust_lib_latest_stable_version, rust_default_model_name),
-        ("-", demo_model_name),
-        ("-", "-"),
+        (
+            rust_cli_latest_stable_version,
+            get_latest_release_tag_url_if_exists(f"cli/v{rust_cli_latest_stable_version}"),
+            rust_default_model_name,
+        ),
+        (
+            python_latest_stable_version,
+            get_latest_release_tag_url_if_exists(
+                f"python-v{python_latest_stable_version}"
+            ),
+            python_default_model_name,
+        ),
+        (
+            javascript_latest_stable_version,
+            get_latest_release_tag_url_if_exists(f"js-v{javascript_latest_stable_version}"),
+            javascript_default_model_name,
+        ),
+        (
+            rust_lib_latest_stable_version,
+            get_latest_release_tag_url_if_exists(
+                f"rust-v{rust_lib_latest_stable_version}"
+            ),
+            rust_default_model_name,
+        ),
+        ("-", None, demo_model_name),
+        ("-", None, "-"),
     ]
 
     # Extract documented last versions and models
@@ -106,11 +127,11 @@ def check_versions_are_up_to_date() -> bool:
         # notice immediately if things break.
         if line.startswith("| ["):
             cols = line.split("|")
-            latest_version = cols[3].strip(" `")
-            default_model = cols[4].strip()
-            if default_model != "-":
-                default_model = default_model.split("]")[0].split("[")[1].strip(" `")
-            parsed_table.append((latest_version, default_model))
+            latest_version, latest_version_url = extract_markdown_text_and_url(
+                cols[3].strip()
+            )
+            default_model, _ = extract_markdown_text_and_url(cols[4].strip())
+            parsed_table.append((latest_version, latest_version_url, default_model))
 
     if expected_table == parsed_table:
         return True
@@ -119,6 +140,31 @@ def check_versions_are_up_to_date() -> bool:
             f"ERROR: Found stale information in binding's overview table:\n{expected_table=}\n{parsed_table=}"
         )
         return False
+
+
+def extract_markdown_text_and_url(cell: str) -> tuple[str, str | None]:
+    if cell == "-":
+        return "-", None
+
+    md_link_match = re.fullmatch(r"\[(.+)\]\((.+)\)", cell)
+    if md_link_match is not None:
+        text = md_link_match.group(1).strip(" `")
+        url = md_link_match.group(2)
+        return text, url
+
+    return cell.strip(" `"), None
+
+
+def get_latest_release_tag_url_if_exists(tag_name: str) -> str | None:
+    api_url = (
+        "https://api.github.com/repos/google/magika/releases/tags/"
+        f"{quote(tag_name, safe='')}"
+    )
+    res = requests.get(api_url)
+    if res.status_code == 404:
+        return None
+    assert res.status_code == 200
+    return f"https://github.com/google/magika/releases/tag/{tag_name}"
 
 
 def get_python_latest_stable_version() -> str:

--- a/website-ng/src/content/docs/cli-and-bindings/overview.md
+++ b/website-ng/src/content/docs/cli-and-bindings/overview.md
@@ -7,8 +7,8 @@ Magika provides a native CLI for command-line use and official language bindings
 
 | Artifact                                                       | Status         | Latest version | Default model                                              |
 | -------------------------------------------------------------- | -------------- | -------------- | ---------------------------------------------------------- |
-| [`magika` CLI](/magika/cli-and-bindings/cli)                          | Stable         | `1.0.2`        | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
-| [Python `Magika` module](/magika/cli-and-bindings/python)             | Stable         | `1.0.2`        | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
+| [`magika` CLI](/magika/cli-and-bindings/cli)                          | Stable         | [`1.0.2`](https://github.com/google/magika/releases/tag/cli/v1.0.2) | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
+| [Python `Magika` module](/magika/cli-and-bindings/python)             | Stable         | [`1.0.2`](https://github.com/google/magika/releases/tag/python-v1.0.2) | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
 | [JavaScript / TypeScript package](/magika/cli-and-bindings/js)        | Stable         | `1.0.0`        | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
 | [Rust `magika` library](/magika/cli-and-bindings/rust)                | Stable         | `1.0.1`        | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
 | [Demo Website](/magika/demo/magika-demo/)                             | Stable         | -              | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |


### PR DESCRIPTION
## Summary
- add GitHub release tag links for the stable CLI and Python rows in the bindings overview table
- extend the documentation checker to validate version link targets when matching release tags exist

Closes #1028.

## Testing
- `LIBRARY_PATH=/home/txh/.local/lib uv run --project /home/txh/magika/python python /home/txh/magika/python/scripts/check_documentation.py`
