### PR TITLE
fix: handle broken pipe gracefully in Rust CLI

### DIFF
--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -15,8 +15,9 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write;
-use std::io::ErrorKind;
+use std::io::{self, ErrorKind, Write as _};
 use std::path::{Path, PathBuf};
+use std::process::{ExitCode, Termination};
 use std::sync::Arc;
 
 use anyhow::{bail, ensure, Result};
@@ -157,7 +158,15 @@ struct Experimental {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> ExitCode {
+    match try_main().await {
+        Ok(code) => code,
+        Err(error) if is_broken_pipe(&error) => ExitCode::SUCCESS,
+        Err(error) => Result::<(), anyhow::Error>::Err(error).report(),
+    }
+}
+
+async fn try_main() -> Result<ExitCode> {
     let mut flags = Flags::parse();
     ensure!(0 < flags.experimental.batch_size, "--batch-size cannot be zero");
     // If --num-tasks is set, we don't do any guessing.
@@ -209,7 +218,7 @@ async fn main() -> Result<()> {
     }
     drop(result_sender);
     if flags.format.json {
-        print!("[");
+        write_stdout("[")?;
     }
     let mut reorder = Reorder::default();
     let mut errors = false;
@@ -218,28 +227,48 @@ async fn main() -> Result<()> {
         while let Some(response) = reorder.pop() {
             errors |= response.result.is_err();
             if flags.format.json {
-                if reorder.next != 1 {
-                    print!(",");
-                }
-                for line in serde_json::to_string_pretty(&response.json()?)?.lines() {
-                    print!("\n  {line}");
-                }
+                write_stdout(&format_json_output(response, reorder.next != 1)?)?;
             } else {
-                println!("{}", response.format(&flags)?);
+                write_stdout(&format!("{}\n", response.format(&flags)?))?;
             }
         }
     }
     debug_assert!(reorder.is_empty());
     if flags.format.json {
         if reorder.next != 0 {
-            println!();
+            write_stdout("\n")?;
         }
-        println!("]");
+        write_stdout("]\n")?;
     }
     if errors {
-        std::process::exit(1);
+        return Ok(ExitCode::FAILURE);
     }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn is_broken_pipe(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .is_some_and(|io_error| io_error.kind() == ErrorKind::BrokenPipe)
+    })
+}
+
+fn write_stdout(output: &str) -> Result<()> {
+    io::stdout().lock().write_all(output.as_bytes())?;
     Ok(())
+}
+
+fn format_json_output(response: Response, needs_comma: bool) -> Result<String> {
+    let mut output = String::new();
+    if needs_comma {
+        output.push(',');
+    }
+    for line in serde_json::to_string_pretty(&response.json()?)?.lines() {
+        output.push_str("\n  ");
+        output.push_str(line);
+    }
+    Ok(output)
 }
 
 async fn extract_features(

--- a/rust/cli/tests/broken_pipe.rs
+++ b/rust/cli/tests/broken_pipe.rs
@@ -1,0 +1,36 @@
+use std::io::{BufRead, BufReader, Read};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+#[test]
+fn exits_cleanly_when_stdout_pipe_closes_early() {
+    let input_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..").join("tests_data/basic");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_magika"))
+        .arg("-r")
+        .arg(&input_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn magika CLI");
+
+    // Read one line so the CLI starts writing, then close the pipe early.
+    let mut stdout = BufReader::new(child.stdout.take().expect("missing stdout pipe"));
+    let mut first_line = String::new();
+    let bytes_read = stdout.read_line(&mut first_line).expect("failed to read CLI output");
+    assert!(bytes_read > 0, "expected at least one line of CLI output");
+    drop(stdout);
+
+    let status = child.wait().expect("failed to wait for magika");
+    let mut stderr = String::new();
+    BufReader::new(child.stderr.take().expect("missing stderr pipe"))
+        .read_to_string(&mut stderr)
+        .expect("failed to read stderr");
+
+    assert!(
+        status.success(),
+        "expected success after broken pipe, got {status}; stderr:\n{stderr}",
+    );
+    assert!(stderr.is_empty(), "expected no stderr output, got:\n{stderr}");
+}


### PR DESCRIPTION
Closes #1354.

When the Rust CLI is used in a normal shell pipeline and the downstream consumer exits early, `magika` currently panics instead of terminating cleanly. That makes commands such as `magika -r … | head` look like crashes, even though the only failure is that stdout is no longer available.

The root cause is that the CLI writes user-facing output through `print!` and `println!`. Those macros go through `std::io::stdio::_print`, which panics on write failures, including `io::ErrorKind::BrokenPipe`. As a result, a downstream pipe closure is treated like an internal crash rather than a normal pipe-termination condition.

This change keeps the fix narrow. The CLI now writes to stdout explicitly so write failures are returned as ordinary `io::Error` values, and the top-level entrypoint treats `BrokenPipe` as a successful exit. Other errors still use the existing error-reporting path, and the per-file error exit behavior is preserved.

I also added a regression test that spawns the CLI, reads one line of output, closes the stdout pipe early, and asserts that the process exits successfully without panic output on stderr. That locks in the exact pipeline behavior reported in the issue without depending on external shell tools.

Validation:
- `cargo test exits_cleanly_when_stdout_pipe_closes_early --test broken_pipe -- --exact`
- `../target/release/magika -r ../../tests_data/basic | head >/dev/null` returned exit code 0 with `set -o pipefail`
- `rust/cli/test.sh` passed `cargo check`, `cargo build --release`, `cargo fmt -- --check`, and `cargo clippy -- --deny=warnings`; its final `/etc/shadow` assertion is Linux-specific and does not hold on macOS because `/etc/shadow` is absent there
