### PR TITLE
docs(website): complete Go binding documentation (#1227)

### DIFF
--- a/website-ng/astro.config.mjs
+++ b/website-ng/astro.config.mjs
@@ -84,6 +84,10 @@ export default defineConfig({
               slug: "cli-and-bindings/js",
             },
             {
+              label: "Go bindings",
+              slug: "cli-and-bindings/go",
+            },
+            {
               label: "Other bindings",
               slug: "cli-and-bindings/other-bindings",
             },

--- a/website-ng/src/content/docs/cli-and-bindings/go.md
+++ b/website-ng/src/content/docs/cli-and-bindings/go.md
@@ -1,0 +1,60 @@
+---
+title: "Go `magika` library"
+---
+
+The Go binding lives in the [`go/`](https://github.com/google/magika/tree/main/go) subdirectory of the Magika repository. It wraps the ONNX Runtime C API and requires [cgo](https://go.dev/blog/cgo).
+
+:::caution
+The Go binding is experimental. It is not yet published as a tagged module and its API may change.
+:::
+
+## Install
+
+Vendor the module directly from the source tree:
+
+```bash
+go get github.com/google/magika/go
+```
+
+You will also need the ONNX Runtime shared library and the Magika asset directory available at build or run time. See the [`go/README.md`](https://github.com/google/magika/blob/main/go/README.md) for setup details, and the [`go/docker/Dockerfile`](https://github.com/google/magika/blob/main/go/docker/Dockerfile) for a complete example.
+
+## Usage
+
+The entry point is `magika.NewScanner`, which loads a model from an asset directory and returns a reusable scanner:
+
+```go
+//go:build cgo && onnxruntime
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/google/magika/go/magika"
+)
+
+func main() {
+	scanner, err := magika.NewScanner("/opt/magika/assets", "standard_v3_3")
+	if err != nil {
+		log.Fatalf("NewScanner failed: %v", err)
+	}
+
+	content := "Hello world"
+	ct, err := scanner.Scan(strings.NewReader(content), len(content))
+	if err != nil {
+		log.Fatalf("Scan failed: %v", err)
+	}
+
+	fmt.Printf("%+v\n", ct)
+}
+```
+
+Build and run it with the `onnxruntime` tag and a link flag pointing at the ONNX Runtime installation:
+
+```bash
+go run -tags onnxruntime -ldflags="-linkmode=external -extldflags=-L/opt/onnxruntime/lib" .
+```
+
+A working end-to-end example is at [`go/example/main.go`](https://github.com/google/magika/blob/main/go/example/main.go), and a more elaborate CLI is at [`go/cli/cli.go`](https://github.com/google/magika/blob/main/go/cli/cli.go).

--- a/website-ng/src/content/docs/cli-and-bindings/other-bindings.md
+++ b/website-ng/src/content/docs/cli-and-bindings/other-bindings.md
@@ -2,11 +2,6 @@
 title: "Other bindings"
 ---
 
-### Go (In Progress)
-A Go port of Magika is currently under development. While the implementation is largely complete, a few final steps are needed before it can be published as a package. You can explore the source code and track its progress on GitHub.
-
-Source Code: github.com/google/magika/tree/main/go
-
 ### Other Languages
 
 Official bindings for other languages are not yet available. However, since Magika's core is built in Rust, it can be integrated into many programming environments using a Foreign Function Interface (FFI). For example:

--- a/website-ng/src/content/docs/cli-and-bindings/overview.md
+++ b/website-ng/src/content/docs/cli-and-bindings/overview.md
@@ -12,4 +12,5 @@ Magika provides a native CLI for command-line use and official language bindings
 | [JavaScript / TypeScript package](/magika/cli-and-bindings/js)        | Stable         | `1.0.0`        | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
 | [Rust `magika` library](/magika/cli-and-bindings/rust)                | Stable         | `1.0.1`        | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
 | [Demo Website](/magika/demo/magika-demo/)                             | Stable         | -              | [`standard_v3_3`](https://github.com/google/magika/blob/main/assets/models/standard_v3_3/README.md) |
+| [Go `magika` library](/magika/cli-and-bindings/go)                    | Experimental   | -              | -                                                          |
 | [Other bindings](/magika/cli-and-bindings/other-bindings)             | WIP            | -              | -                                                          |


### PR DESCRIPTION
## Summary

Completes the three remaining checklist items on the GoLang bindings tracking issue by updating the website-ng docs to reflect the Go binding that already exists under `go/`.

## Why this matters

Issue #1227 tracks outstanding Go binding work. Two earlier items landed in #1235 (tests) and #1241 (README badge), both merged November 2025. The website surface was never updated to match, so new users landing on the docs still see "Go (In Progress)" with no entry point to the binding.

## Changes

- `website-ng/src/content/docs/cli-and-bindings/overview.md`: new Go row in the bindings table, marked Experimental, linking to the new landing page.
- `website-ng/src/content/docs/cli-and-bindings/go.md`: new landing page modeled on `rust.md` and `python.md`. Mirrors the usage pattern from `go/example/main.go` (`magika.NewScanner` + `scanner.Scan`) and links to `go/README.md`, `go/example/main.go`, `go/cli/cli.go`, and `go/docker/Dockerfile` for setup and a more elaborate example.
- `website-ng/src/content/docs/cli-and-bindings/other-bindings.md`: remove the "Go (In Progress)" section now that Go has a first-class page.
- `website-ng/astro.config.mjs`: register the new Go page in the Starlight sidebar alongside the other bindings.

Checklist items from #1227 now covered:

- [x] add GoLang to the overview bindings table
- [x] add a landing page for the GoLang binding
- [x] remove reference to GoLang in the "other bindings" page

## Testing

`npx astro check` in `website-ng/`: 0 errors, 0 warnings, 0 hints across 18 files.

No prose edits to existing pages beyond the two section changes above.

Fixes #1227

This contribution was developed with AI assistance (Codex).
