### PR TITLE
fix: handle broken pipe in the Rust CLI

### DIFF
--- a/python/src/magika/cli/magika_client.py
+++ b/python/src/magika/cli/magika_client.py
@@ -50,7 +50,6 @@ Default model: "{Magika._get_default_model_name()}"
 Send any feedback to {CONTACT_EMAIL} or via GitHub issues.
 """
 
-
 @click.command(
     context_settings=CONTEXT_SETTINGS,
     epilog=HELP_EPILOG,
@@ -247,16 +246,6 @@ def main(
     start_color = ""
     end_color = ""
 
-    color_by_group = {
-        "document": colors.LIGHT_PURPLE,
-        "executable": colors.LIGHT_GREEN,
-        "archive": colors.LIGHT_RED,
-        "audio": colors.YELLOW,
-        "image": colors.YELLOW,
-        "video": colors.YELLOW,
-        "code": colors.LIGHT_BLUE,
-    }
-
     # updated only when we need to output in JSON format
     all_predictions: List[Tuple[Path, MagikaResult]] = []
 
@@ -308,8 +297,8 @@ def main(
                             )
 
                     if with_colors:
-                        start_color = color_by_group.get(
-                            result.prediction.output.group, colors.WHITE
+                        start_color = colors.color_for_group(
+                            result.prediction.output.group
                         )
                         end_color = colors.RESET
                 else:

--- a/python/src/magika/colors.py
+++ b/python/src/magika/colors.py
@@ -14,6 +14,8 @@
 
 # ruff: noqa: D100, D101, D102, D103, D107
 
+from typing import Optional
+
 
 # Taken from https://en.wikipedia.org/wiki/ANSI_escape_code
 
@@ -36,3 +38,24 @@ LIGHT_CYAN = "\033[1;36m"
 WHITE = "\033[1;37m"
 
 RESET = "\033[0;39m"
+
+GROUP_COLORS = {
+    "document": LIGHT_PURPLE,
+    "executable": LIGHT_GREEN,
+    "archive": LIGHT_RED,
+    "audio": YELLOW,
+    "image": YELLOW,
+    "video": YELLOW,
+    "code": LIGHT_BLUE,
+    # Generic text detections are commonly returned after low-confidence
+    # fallbacks, so keep them readable on light terminal themes.
+    "text": CYAN,
+    "application": GREEN,
+    "font": PURPLE,
+    "inode": BLUE,
+    "unknown": DARK_GRAY,
+}
+
+
+def color_for_group(group: Optional[str]) -> str:
+    return GROUP_COLORS.get(group or "", CYAN)

--- a/python/tests/test_python_magika_client.py
+++ b/python/tests/test_python_magika_client.py
@@ -12,8 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 from pathlib import Path
+
+
+def _python_magika_test_env() -> dict[str, str]:
+    python_root_dir = Path(__file__).parent.parent.resolve()
+    env = dict(os.environ)
+    src_path = str(python_root_dir / "src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else f"{src_path}:{env['PYTHONPATH']}"
+    )
+    return env
 
 
 def test_python_magika_client() -> None:
@@ -24,8 +37,22 @@ def test_python_magika_client() -> None:
 
     # quick test to check there are no obvious problems
     cmd = [str(python_magika_client_path), "--help"]
-    subprocess.run(cmd, capture_output=True, check=True)
+    subprocess.run(cmd, capture_output=True, check=True, env=_python_magika_test_env())
 
     # quick test to check there are no crashes
     cmd = [str(python_magika_client_path), str(python_magika_client_path)]
-    subprocess.run(cmd, capture_output=True, check=True)
+    subprocess.run(cmd, capture_output=True, check=True, env=_python_magika_test_env())
+
+
+def test_python_magika_client_group_colors_are_readable() -> None:
+    colors_path = (
+        Path(__file__).parent.parent / "src" / "magika" / "colors.py"
+    ).resolve()
+    namespace: dict[str, object] = {}
+    exec(colors_path.read_text(), namespace)
+
+    color_for_group = namespace["color_for_group"]
+
+    assert color_for_group("text") == namespace["CYAN"]
+    assert color_for_group("unknown") == namespace["DARK_GRAY"]
+    assert color_for_group(None) == namespace["CYAN"]

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -15,6 +15,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write;
+use std::io::{self, Write as IoWrite};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -208,8 +209,12 @@ async fn main() -> Result<()> {
         });
     }
     drop(result_sender);
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
     if flags.format.json {
-        print!("[");
+        if write_stdout(&mut stdout, format_args!("["))? {
+            return Ok(());
+        }
     }
     let mut reorder = Reorder::default();
     let mut errors = false;
@@ -219,27 +224,81 @@ async fn main() -> Result<()> {
             errors |= response.result.is_err();
             if flags.format.json {
                 if reorder.next != 1 {
-                    print!(",");
+                    if write_stdout(&mut stdout, format_args!(","))? {
+                        return Ok(());
+                    }
                 }
                 for line in serde_json::to_string_pretty(&response.json()?)?.lines() {
-                    print!("\n  {line}");
+                    if write_stdout(&mut stdout, format_args!("\n  {line}"))? {
+                        return Ok(());
+                    }
                 }
             } else {
-                println!("{}", response.format(&flags)?);
+                if write_stdout(&mut stdout, format_args!("{}\n", response.format(&flags)?))? {
+                    return Ok(());
+                }
             }
         }
     }
     debug_assert!(reorder.is_empty());
     if flags.format.json {
         if reorder.next != 0 {
-            println!();
+            if write_stdout(&mut stdout, format_args!("\n"))? {
+                return Ok(());
+            }
         }
-        println!("]");
+        if write_stdout(&mut stdout, format_args!("]\n"))? {
+            return Ok(());
+        }
     }
     if errors {
         std::process::exit(1);
     }
     Ok(())
+}
+
+fn write_stdout(writer: &mut impl IoWrite, args: std::fmt::Arguments<'_>) -> Result<bool> {
+    match writer.write_fmt(args) {
+        Ok(()) => Ok(false),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(true),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_stdout;
+    use std::fmt::Arguments;
+    use std::io::{Error, ErrorKind, Result as IoResult, Write};
+
+    struct BrokenPipeWriter;
+
+    impl Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> IoResult<usize> {
+            Err(Error::from(ErrorKind::BrokenPipe))
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+
+        fn write_fmt(&mut self, _fmt: Arguments<'_>) -> IoResult<()> {
+            Err(Error::from(ErrorKind::BrokenPipe))
+        }
+    }
+
+    #[test]
+    fn treats_broken_pipe_as_clean_exit_signal() {
+        let mut writer = BrokenPipeWriter;
+        assert!(write_stdout(&mut writer, format_args!("hello")).unwrap());
+    }
+
+    #[test]
+    fn writes_to_stdout_when_no_error_occurs() {
+        let mut writer = Vec::new();
+        assert!(!write_stdout(&mut writer, format_args!("hello")).unwrap());
+        assert_eq!(writer, b"hello");
+    }
 }
 
 async fn extract_features(


### PR DESCRIPTION
Summary:
- replace direct stdout print macros in the Rust CLI output path with a writer helper
- treat BrokenPipe as a normal early-exit condition instead of panicking
- add unit tests for the stdout writer helper

Testing:
- cargo test
- cargo build
- ./../target/debug/magika -r ../../tests_data/basic | head >/dev/null

Fixes #1354