### PR TITLE
build: bump actions/upload-artifact from v4 to v5

### DIFF
--- a/.github/workflows/python-build-and-release-package.yml
+++ b/.github/workflows/python-build-and-release-package.yml
@@ -111,7 +111,7 @@ jobs:
           args: --release --out=../dist
           working-directory: python
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheel-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
           path: dist
@@ -199,12 +199,12 @@ jobs:
         run: uv build --out-dir ../dist
         working-directory: python
       - name: Upload pure python wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: wheel-pure-python
           path: dist/*.whl
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sdist
           path: dist/*.tar.gz


### PR DESCRIPTION
## Summary

Bumps `actions/upload-artifact` from version 4 to version 5 in the `python-build-and-release-package.yml` workflow.

## Changes

- Updated 3 occurrences of `actions/upload-artifact@v4` to `actions/upload-artifact@v5`

## Testing

CI workflow should pass with the updated action version.

Closes #1218