### PR TITLE
python: treat dotenv files with html values as text

### DIFF
--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -735,7 +735,20 @@ class Magika:
             )
             return result, None
 
-        elif seekable.size < self._model_config.min_file_size_for_dl:
+        bytes_to_read = min(seekable.size, self._model_config.block_size)
+        label = Magika._get_label_from_dotenv_path_and_content(
+            path, seekable.read_at(0, bytes_to_read)
+        )
+        if label is not None:
+            result = self._get_result_from_labels_and_score(
+                path=path,
+                dl_label=ContentTypeLabel.UNDEFINED,
+                output_label=label,
+                score=1.0,
+            )
+            return result, None
+
+        if seekable.size < self._model_config.min_file_size_for_dl:
             content = seekable.read_at(0, seekable.size)
             result = self._get_result_from_few_bytes(content, path=path)
             return result, None
@@ -790,6 +803,33 @@ class Magika:
         except UnicodeDecodeError:
             label = ContentTypeLabel.UNKNOWN
         return label
+
+    @staticmethod
+    def _get_label_from_dotenv_path_and_content(
+        path: Path, content: bytes
+    ) -> Optional[ContentTypeLabel]:
+        if path.name != ".env" and not path.name.startswith(".env."):
+            return None
+
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+
+        for line in text.splitlines():
+            stripped_line = line.strip()
+            if (
+                not stripped_line
+                or stripped_line.startswith("#")
+                or "=" not in stripped_line
+            ):
+                continue
+
+            key, _ = stripped_line.split("=", 1)
+            if key and all(c.isalnum() or c == "_" for c in key):
+                return ContentTypeLabel.TXT
+
+        return None
 
     def _get_raw_predictions(
         self, features: List[Tuple[Path, ModelFeatures]]

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -205,6 +205,27 @@ def test_magika_module_with_short_content() -> None:
             assert res.prediction.score == 1.0
 
 
+def test_magika_module_with_env_file_containing_html_values() -> None:
+    env_content = (
+        b'text="<html><head></head><body></body></html>"\n'
+        b'value="1234"\n'
+        b'body="<h1>kokot</h1>"\n'
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        tf_path = Path(td) / ".env"
+        tf_path.write_bytes(env_content)
+
+        m = Magika()
+        res = m.identify_path(tf_path)
+
+        assert res.path == tf_path
+        assert res.ok
+        assert res.prediction.dl.label == ContentTypeLabel.UNDEFINED
+        assert res.prediction.output.label == ContentTypeLabel.TXT
+        assert res.prediction.score == 1.0
+
+
 def test_magika_module_with_python_and_non_python_content() -> None:
     python_content = (
         b"import flask\nimport requests\n\ndef foo(a):\n    print(f'Test {a}')\n"


### PR DESCRIPTION
﻿## Summary
- detect dotenv-style `.env` files as generic text before HTML-like values reach the model path
- keep the override path-scoped and content-gated to UTF-8 key/value lines
- add a regression for the `.env` sample from #1248

## Issue
- Fixes #1248

## Verification
- `uv run --project python pytest python/tests/test_magika_python_module.py::test_magika_module_with_env_file_containing_html_values -q`
- `uv run --project python pytest python/tests/test_magika_python_module.py::test_magika_module_with_short_content python/tests/test_magika_python_module.py::test_magika_module_with_python_and_non_python_content python/tests/test_magika_python_module.py::test_magika_module_with_env_file_containing_html_values -q`
- `uv run --project python ruff check python/src/magika/magika.py python/tests/test_magika_python_module.py`
- `uv run --project python ruff format --check python/src/magika/magika.py python/tests/test_magika_python_module.py`
