### PR TITLE
fix: MagikaResult.__post_init__ validation was never called

### DIFF
--- a/python/src/magika/types/magika_result.py
+++ b/python/src/magika/types/magika_result.py
@@ -43,8 +43,9 @@ class MagikaResult:
         self._path = path
         self._status = status
         self._prediction = prediction
+        self._validate()
 
-    def __post_init__(self) -> None:
+    def _validate(self) -> None:
         assert self._path is not None
         if self._status == Status.OK:
             if self._prediction is None:


### PR DESCRIPTION
## 🐞 Problem/Bug

``MagikaResult`` contains ``__post_init__`` method that checks object invariants.
``If status == OK``, then prediction must be set.
``If status != OK``, then prediction must be None.

However, MagikaResult is a regular class, not a ``@dataclass``  the ``__post_init__`` method is only called in the dataclass. Within the class, it simply exists as a regular method that is never called. As a result, **validation is completely ineffective**

---

## Solution

Renamed ``__post_init__`` to ``_validate()`` and added a call to ``self._validate()`` at the end ``of __init__`` the minimal change is that the validation logic remains unchanged, only now it is actually executed.


*This problem doesn't interfere with the tool's operation, but someone created it specifically; it should protect against errors and not just lie there like dead weight.*
