### PR TITLE
test: enable python suite on windows

### DIFF
--- a/.github/workflows/python-test-suite.yml
+++ b/.github/workflows/python-test-suite.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v4

--- a/python/tests/test_magika_python_module.py
+++ b/python/tests/test_magika_python_module.py
@@ -14,6 +14,7 @@
 
 import io
 import signal
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any, List, Optional
@@ -496,6 +497,10 @@ def test_magika_module_multiple_copies_of_the_same_file() -> None:
             assert result.prediction.output.label == ContentTypeLabel.TXT
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Creating symlinks on Windows requires developer mode or elevated privileges.",
+)
 def test_magika_module_with_symlink() -> None:
     with tempfile.TemporaryDirectory() as td:
         test_path = Path(td) / "test.txt"
@@ -537,6 +542,10 @@ def test_magika_module_with_non_existing_file() -> None:
         assert res.status == Status.FILE_NOT_FOUND_ERROR
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="chmod does not reliably make files unreadable on Windows.",
+)
 def test_magika_module_with_permission_error() -> None:
     m = Magika()
 
@@ -586,10 +595,16 @@ def test_magika_module_with_really_many_files() -> None:
 
 @pytest.mark.slow
 def test_magika_module_with_big_file() -> None:
+    sigalrm: Any = getattr(signal, "SIGALRM", None)
+    alarm: Any = getattr(signal, "alarm", None)
+
+    if sigalrm is None or alarm is None:
+        pytest.skip("signal alarm timeouts are not available on this platform")
+
     def signal_handler(signum: int, frame: Any) -> None:
         raise Exception("Timeout")
 
-    signal.signal(signal.SIGALRM, signal_handler)
+    signal.signal(sigalrm, signal_handler)
 
     # It should take much less than this, but pytest weird scheduling sometimes
     # creates unexpected slow downs.
@@ -602,10 +617,10 @@ def test_magika_module_with_big_file() -> None:
             sample_path = Path(td) / "sample.dat"
             utils.write_random_file_with_size(sample_path, sample_size)
             print(f"Starting running Magika with a timeout of {timeout}")
-            signal.alarm(timeout)
+            alarm(timeout)
             res = m.identify_path(sample_path)
             assert res.ok
-            signal.alarm(0)
+            alarm(0)
             print("Done running Magika")
 
 


### PR DESCRIPTION
Fixes #789.

## Summary

- add `windows-latest` to the Python test-suite matrix
- skip symlink and chmod permission tests on Windows where those assumptions are platform-specific
- make the slow big-file timeout test skip when `signal.alarm` / `SIGALRM` are unavailable, avoiding Windows mypy failures while keeping the timeout active on POSIX platforms

## Verification

- `uv run --python 3.11 ruff check`
- `uv run --python 3.11 ruff format --check tests/test_magika_python_module.py`
- `uv run --python 3.11 mypy src/magika tests`
- `uv run --python 3.11 pytest tests -m "not slow"`
