### PR TITLE
docs: clarify Python threading usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ ini
 ini
 ```
 
+`Magika` instances can be reused for concurrent identification calls. When
+using `identify_stream`, pass a distinct stream object to each concurrent call:
+Magika seeks and reads the provided stream, then restores its original position.
+
 For more examples and documentation about the Python module, see the [Python `Magika` module](https://securityresearch.google/magika/cli-and-bindings/python/) section.
 
 

--- a/python/README.md
+++ b/python/README.md
@@ -199,6 +199,10 @@ ini
 ini
 ```
 
+`Magika` instances can be reused for concurrent identification calls. When
+using `identify_stream`, pass a distinct stream object to each concurrent call:
+Magika seeks and reads the provided stream, then restores its original position.
+
 
 ## Core Concepts
 

--- a/python/src/magika/magika.py
+++ b/python/src/magika/magika.py
@@ -180,7 +180,8 @@ class Magika:
         Identifies the content type from an already-open binary file-like object
         (e.g., the output of `open(file_path, 'rb')`). Note: 1) Magika will
         `seek()` around the stream; 2) the stream _is not closed_ (closing it is
-        the responsibility of the caller).
+        the responsibility of the caller). When calling Magika concurrently, use
+        a distinct stream object for each call.
         """
         if not isinstance(stream, io.IOBase) or not stream.readable():  # type: ignore[unreachable]
             raise TypeError("Input stream must be a readable BinaryIO object.")


### PR DESCRIPTION
Fixes #256

This clarifies that Python `Magika` instances can be reused for concurrent identification calls, while `identify_stream` callers should pass distinct stream objects because Magika seeks and reads the provided stream before restoring its position.

Verification:
- `python3 -m py_compile python/src/magika/magika.py`
- `git diff --check`