### PR TITLE
docs: clarify content type metadata fields

### DIFF
--- a/website-ng/src/content/docs/cli-and-bindings/python.md
+++ b/website-ng/src/content/docs/cli-and-bindings/python.md
@@ -150,6 +150,11 @@ class ContentTypeInfo:
     is_text: bool           # e.g., True
 ```
 
+Older Python releases exposed compatibility names such as `magic` for
+`description` and stored `score` on `ContentTypeInfo`. These names are
+deprecated or unsupported in current releases; use `description` and the
+`MagikaResult.score` field instead.
+
 `ContentTypeLabel`
 
 A string enum (`StrEnum`) of all possible content type labels. Because it's a `StrEnum`, its members can be used and compared just like regular strings.

--- a/website-ng/src/content/docs/core-concepts/understanding-the-output.md
+++ b/website-ng/src/content/docs/core-concepts/understanding-the-output.md
@@ -70,6 +70,11 @@ Within both `dl` and `output`, you will find:
 - `is_text`: A boolean indicating if the content is textual.
 - `extensions`: A list of common file extensions for this content type.
 
+In current Magika versions these are the supported metadata fields. Older Python
+releases exposed compatibility names such as `magic` for the human-readable
+description and stored `score` on the content type object itself. Use
+`description` and the top-level `score` field instead.
+
 As mentioned previously, when the model is not used (e.g., for empty files), `dl.label` is set to `undefined`, and the output block will contain a generic content type like `txt` or `unknown`.
 
 For most applications, you should use the `output.label` field, which is the default output of the CLI. The raw `dl` block is provided primarily for debugging and advanced use cases.


### PR DESCRIPTION
## Summary
- docs: clarify content type metadata fields

## Changed files
- `website-ng/src/content/docs/cli-and-bindings/python.md`
- `website-ng/src/content/docs/core-concepts/understanding-the-output.md`

## Tests
- Not run in this publishing pass; local branch was clean before opening the PR.
