### PR TITLE
Fix CI failures in Windows

### DIFF
--- a/python/scripts/pre_release_check.py
+++ b/python/scripts/pre_release_check.py
@@ -18,6 +18,7 @@ It performs a number of checks to determine whether the package is ready for rel
 """
 
 import re
+import shutil
 import subprocess
 import sys
 
@@ -148,9 +149,36 @@ def get_rust_cli_version() -> str:
 
     Returns an empty string ("") if an error is encountered.
     """
+    import os
+    import sysconfig
+    from pathlib import Path
+
+    client_path = shutil.which("magika")
+    cmd = []
+    if client_path:
+        cmd = [client_path]
+    else:
+        # Try manual resolution on Windows if shutil.which failed
+        if os.name == "nt":
+            candidate = Path(sysconfig.get_path("scripts")) / "magika"
+            if candidate.is_file():
+                cmd = [str(candidate)]
+                # Check if it is a python script
+                try:
+                    with open(candidate, "r", encoding="utf-8", errors="replace") as f:
+                        if "python" in f.readline():
+                            cmd = [sys.executable, str(candidate)]
+                            click.echo(
+                                f"Windows workaround in pre-release check: running Python script with {sys.executable}"
+                            )
+                except Exception:
+                    pass
+        if not cmd:
+            cmd = ["magika"]  # fallback
+
     try:
         result = subprocess.run(
-            ["magika", "--version"], capture_output=True, text=True, check=True
+            cmd + ["--version"], capture_output=True, text=True, check=True
         )
         parts = result.stdout.strip().split()
         if len(parts) < 2:

--- a/python/scripts/run_quick_test_magika_cli.py
+++ b/python/scripts/run_quick_test_magika_cli.py
@@ -23,12 +23,35 @@ magika`; this script is used as part of "build & test package" github action,
 and the dev dependencies are not available.
 """
 
+import os
+import shutil
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import click
+
+
+def get_execute_cmd(client_path: Path) -> List[str]:
+    if os.name == "nt" and not client_path.is_absolute():
+        candidate = Path(sysconfig.get_path("scripts")) / client_path.name
+        if candidate.is_file():
+            client_path = candidate
+            print(f"Manually resolved {client_path.name} to {client_path}")
+
+    if os.name == "nt" and client_path.is_file() and client_path.suffix == "":
+        try:
+            with open(client_path, "r", encoding="utf-8", errors="replace") as f:
+                if "python" in f.readline():
+                    print(
+                        f"Windows workaround: running Python script with {sys.executable}"
+                    )
+                    return [sys.executable, str(client_path)]
+        except Exception as e:
+            print(f"Failed to check if file is script: {e}")
+    return [str(client_path)]
 
 
 @click.command()
@@ -49,14 +72,25 @@ def main(client_path: Optional[Path]) -> None:
     assert basic_tests_dir.is_dir()
 
     if client_path is None:
-        client_path = Path("magika")
-    print(f'Testing client: "{client_path}"')
+        client_path_str = "magika"
+    else:
+        client_path_str = str(client_path)
 
-    p = subprocess.run([str(client_path), "--version"], capture_output=True, text=True)
-    print(f'Output of "magika --version": {p.stdout.strip()}')
+    resolved_path = shutil.which(client_path_str)
+    if resolved_path:
+        client_path = Path(resolved_path)
+    else:
+        client_path = Path(client_path_str)
+
+    print(f'Testing client: "{client_path_str}" (resolved to: "{client_path}")')
+
+    cmd = get_execute_cmd(client_path)
+
+    p = subprocess.run(cmd + ["--version"], capture_output=True, text=True)
+    print(f'Output of "{client_path_str} --version": {p.stdout.strip()}')
 
     p = subprocess.run(
-        [str(client_path), "-r", "--label", "--no-colors", str(basic_tests_dir)],
+        cmd + ["-r", "--label", "--no-colors", str(basic_tests_dir)],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
This is vibe-coded. Below is what the agent had to say.

---

This PR fixes a `FileNotFoundError` that occurs on Windows CI runners during package testing.

### The Problem
When building mixed Rust/Python packages with `maturin` using `bindings = "bin"`, `maturin` packages the Rust CLI binary inside the wheel and installs a small Python launcher script (which handles DLL loading for `onnxruntime` on Windows) into the wheel's `scripts` directory. 

On Windows, `pip` installs this launcher script into the environment's `Scripts` folder as `magika` **without a `.exe` extension**. Because it lacks an extension, Windows' `CreateProcess` API (invoked by Python's `subprocess.run(..., shell=False)`) fails to execute it directly, resulting in:
```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

### The Solution
Instead of trying to alter how `maturin` or `pip` packages the wheel on Windows, this PR implements a robust, portable workaround in the test/check scripts (`run_quick_test_magika_cli.py` and `pre_release_check.py`):

1. **Script Directory Resolution**: On Windows, if the CLI tool cannot be found via `shutil.which` (due to the missing extension), the scripts now manually locate it in the active environment's standard `Scripts` directory using `sysconfig.get_path("scripts")`.
2. **Shebang Detection**: If an extensionless candidate is found, the script peeks at the first line. If it contains a Python shebang (`#!`), it is identified as the launcher script.
3. **Explicit Python Invocation**: The command is rewritten to run explicitly via the current Python interpreter (`sys.executable`):
   `python.exe C:\...\Scripts\magika --version`
   This bypasses the Windows execution limitation and successfully boots the Rust client via the launcher.

### Why this approach?
* **No `bash` dependency**: Avoids assuming `bash` is present, ensuring the test suite remains runnable locally for Windows developers using standard PowerShell/CMD.
* **Zero Path/Escaping Issues**: Avoids POSIX path conversion errors that commonly happen when passing Windows backslash paths to `bash`.
* **Clean & Standard**: Leverages `sysconfig` to find the installation directory reliably across all Python versions (3.8+).
