### PR TITLE
js: fix CLI model config flag mapping

### DIFF
--- a/js/magika-cli.ts
+++ b/js/magika-cli.ts
@@ -22,6 +22,7 @@ import { CommanderError, program } from "commander";
 import * as fs from "fs";
 import { readFile } from "fs/promises";
 import { MagikaNode as Magika } from "./magika-node.js";
+import { getMagikaOptionsFromFlags } from "./src/magika-cli-options.js";
 
 program
   .description(
@@ -65,12 +66,7 @@ try {
 const flags = program.opts();
 
 (async () => {
-  const magika = await Magika.create({
-    modelURL: flags.modelUrl,
-    modelPath: flags.modelPath,
-    modelConfigURL: flags.configUrl,
-    modelConfigPath: flags.configPath,
-  });
+  const magika = await Magika.create(getMagikaOptionsFromFlags(flags));
   await Promise.all(
     program.args.map(async (path) => {
       let data = null;

--- a/js/src/magika-cli-options.ts
+++ b/js/src/magika-cli-options.ts
@@ -1,0 +1,33 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { MagikaOptions } from "./magika-options.js";
+
+export interface MagikaCliFlags {
+  modelUrl?: string;
+  modelPath?: string;
+  modelConfigUrl?: string;
+  modelConfigPath?: string;
+}
+
+export function getMagikaOptionsFromFlags(
+  flags: MagikaCliFlags,
+): MagikaOptions {
+  return {
+    modelURL: flags.modelUrl,
+    modelPath: flags.modelPath,
+    modelConfigURL: flags.modelConfigUrl,
+    modelConfigPath: flags.modelConfigPath,
+  };
+}

--- a/js/test/magika-cli.test.ts
+++ b/js/test/magika-cli.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from "@jest/globals";
 import { spawn } from "child_process";
 import path from "path";
+import { getMagikaOptionsFromFlags } from "../src/magika-cli-options.js";
 
 describe("magika-cli.ts CLI Tests", () => {
   const scriptPath = path.resolve(__dirname, "../dist/mjs/magika-cli.js");
@@ -45,6 +46,22 @@ describe("magika-cli.ts CLI Tests", () => {
       });
     });
   }
+
+  it("should map model config flags if custom config flags are provided", () => {
+    expect(
+      getMagikaOptionsFromFlags({
+        modelUrl: "https://example.invalid/model.json",
+        modelPath: "/tmp/model.json",
+        modelConfigUrl: "https://example.invalid/config.json",
+        modelConfigPath: "/tmp/config.json",
+      }),
+    ).toEqual({
+      modelURL: "https://example.invalid/model.json",
+      modelPath: "/tmp/model.json",
+      modelConfigURL: "https://example.invalid/config.json",
+      modelConfigPath: "/tmp/config.json",
+    });
+  });
 
   it("should display help information when no arguments are provided", async () => {
     const { stdout, stderr, exitCode } = await executeCli();


### PR DESCRIPTION
## Summary

Fix the JS CLI so `--model-config-url` and `--model-config-path` are forwarded to `Magika.create()` correctly.

Fixes #1404.

## Root Cause

The CLI defines `--model-config-url` and `--model-config-path`, but Commander exposes those options as `flags.modelConfigUrl` and `flags.modelConfigPath`.

The CLI was still reading the old `flags.configUrl` and `flags.configPath` names, so custom model config flags were ignored and the default config was used instead.

## Changes

- route CLI flags through a dedicated helper that maps parsed Commander flags to `MagikaOptions`
- fix the `modelConfigURL` / `modelConfigPath` wiring to use `modelConfigUrl` / `modelConfigPath`
- add a regression test that locks the mapping in place

## Validation

- `corepack yarn build`
- `node ./node_modules/jest/bin/jest.js test/magika-cli.test.ts --runInBand --modulePathIgnorePatterns dist`
- `corepack yarn test` still hits an unrelated existing failure in `test/magika.test.ts` on my machine (`dirent.parentPath` is undefined), while the CLI test file passes
