### PR TITLE
fix: update installer script URLs to point to the latest releases

### DIFF
--- a/website-ng/src/pages/install.ps1.ts
+++ b/website-ng/src/pages/install.ps1.ts
@@ -5,7 +5,7 @@ export const prerender = false;
 export async function GET({ redirect }: APIContext) {
   console.log("Redirecting to latest installer script");
   return redirect(
-    "https://github.com/google/magika/releases/latest/download/magika-cli-installer.ps1",
+    "https://github.com/google/magika/releases/download/cli-latest/magika-cli-installer.ps1",
     302
   );
 }

--- a/website-ng/src/pages/install.ps1.ts
+++ b/website-ng/src/pages/install.ps1.ts
@@ -5,7 +5,7 @@ export const prerender = false;
 export async function GET({ redirect }: APIContext) {
   console.log("Redirecting to latest installer script");
   return redirect(
-    "https://github.com/google/magika/releases/download/cli-latest/magika-installer.ps1",
+    "https://github.com/google/magika/releases/latest/download/magika-cli-installer.ps1",
     302
   );
 }

--- a/website-ng/src/pages/install.sh.ts
+++ b/website-ng/src/pages/install.sh.ts
@@ -5,7 +5,7 @@ export const prerender = false;
 export async function GET({ redirect }: APIContext) {
   console.log("Redirecting to latest installer script");
   return redirect(
-    "https://github.com/google/magika/releases/download/cli-latest/magika-installer.sh",
+    "https://github.com/google/magika/releases/latest/download/magika-cli-installer.sh",
     302
   );
 }

--- a/website-ng/src/pages/install.sh.ts
+++ b/website-ng/src/pages/install.sh.ts
@@ -5,7 +5,7 @@ export const prerender = false;
 export async function GET({ redirect }: APIContext) {
   console.log("Redirecting to latest installer script");
   return redirect(
-    "https://github.com/google/magika/releases/latest/download/magika-cli-installer.sh",
+    "https://github.com/google/magika/releases/download/cli-latest/magika-cli-installer.sh",
     302
   );
 }


### PR DESCRIPTION
Fixes broken installer script URLs in the README. The previous redirect targets returned 404 errors and pointed to an invalid release path. Updated the install.sh and install.ps1 links to use the correct latest release download locations, resolving issue #1408 