### PR TITLE
Add RPM package installer via cargo-dist

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell", "powershell", "rpm"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in


### PR DESCRIPTION
The project uses cargo-dist to manage release artifacts. cargo-dist has native support for generating RPM packages through its `"rpm"` installer type, which produces `.rpm` files that can be distributed via yum/dnf repositories.

This change adds `"rpm"` to the `installers` list in `dist-workspace.toml`. On the next tagged CLI release, cargo-dist will generate an RPM package alongside the existing shell and PowerShell installers. The RPM targets the existing Linux platforms already listed in `targets` (`aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu`).

No additional configuration is required — cargo-dist handles RPM packaging automatically once the installer type is declared.

Fixes #100