### PR TITLE
Add basic test samples for shell, go, and sql content types

### DIFF
--- a/tests_data/basic/go/main.go
+++ b/tests_data/basic/go/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func add(a, b int) int {
+	return a + b
+}
+
+func main() {
+	result := add(3, 4)
+	fmt.Printf("3 + 4 = %d\n", result)
+}

--- a/tests_data/basic/shell/script.sh
+++ b/tests_data/basic/shell/script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# A simple shell script that greets the user
+
+NAME=${1:-"World"}
+
+greet() {
+    echo "Hello, $NAME!"
+}
+
+if [ -z "$NAME" ]; then
+    echo "Usage: $0 <name>"
+    exit 1
+fi
+
+greet
+exit 0

--- a/tests_data/basic/sql/query.sql
+++ b/tests_data/basic/sql/query.sql
@@ -1,0 +1,16 @@
+-- Sample SQL script
+
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com');
+INSERT INTO users (name, email) VALUES ('Bob', 'bob@example.com');
+
+SELECT id, name, email
+FROM users
+WHERE created_at > '2024-01-01'
+ORDER BY name ASC;


### PR DESCRIPTION
This PR adds "basic" test samples for three common content types that were previously missing from `tests_data/basic/`:

- **`shell`** (`tests_data/basic/shell/script.sh`): A straightforward Bash script with a function, argument handling, and exit codes. Written from scratch.
- **`go`** (`tests_data/basic/go/main.go`): A minimal Go program with a helper function and a `main` entry point. Written from scratch.
- **`sql`** (`tests_data/basic/sql/query.sql`): A SQL script that creates a table, inserts rows, and runs a SELECT query. Written from scratch.

All three samples are hand-written originals, not taken from any existing project or online resource, and are intended to be clear-cut examples that the model should recognize without difficulty.

Fixes #662