### PR TITLE
security: run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,23 @@
 ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-slim as base
 
+# 1. Create a dedicated non-root user and group
+RUN groupadd -r magika && useradd -r -g magika magika
+
 WORKDIR /magika
 
-# This requires buildx
-# RUN --mount=type=cache,target=/root/.cache/pip \
-#     pip install magika
+# 2. Change ownership of the working directory
+RUN chown magika:magika /magika
 
-RUN pip install magika
+# 3. Install Magika (Pinned version and cache disabled for a smaller image)
+ARG MAGIKA_VERSION=1.0.3
+RUN pip install --no-cache-dir magika==${MAGIKA_VERSION}
+
+# 4. Switch to the non-root user
+USER magika
+
+# 5. Add a basic healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD magika --version || exit 1
 
 ENTRYPOINT ["magika"]


### PR DESCRIPTION
This PR updates the production `Dockerfile` to apply container hardening and security best practices as requested in the issue #1406 .

### Changes Made:
- **Non-root user execution:** Created a dedicated system user/group (`magika`) and set `USER magika` to prevent running the container as `root` (`uid=0`).
- **Version pinning:** Pinned the `magika` PyPI package version (`1.0.3`) using `ARG MAGIKA_VERSION` to ensure build reproducibility.
- **Image optimization:** Added `--no-cache-dir` to `pip install` to reduce the final image size.
- **Healthcheck:** Added a `HEALTHCHECK` instruction using `magika --version`.

### Verification:
Built and tested the image locally:
```bash
docker build -t magika-secure .
docker run --rm --entrypoint id magika-secure
Output: uid=999(magika) gid=999(magika) groups=999(magika)