### PR TITLE
test: add basic AWK, BibTeX, and HCL samples

### DIFF
--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -70,15 +70,15 @@ cargo install --locked --path=rust/cli
 ```shell
 % cd tests_data/basic && magika -r * | head
 asm/code.asm: Assembly (code)
+awk/weekly_totals.awk: Awk (code)
 batch/simple.bat: DOS batch file (code)
+bib/references.bib: BibTeX (text)
 c/code.c: C source (code)
 css/code.css: CSS source (code)
 csv/magika_test.csv: CSV document (code)
 dockerfile/Dockerfile: Dockerfile (code)
 docx/doc.docx: Microsoft Word 2007+ document (document)
 docx/magika_test.docx: Microsoft Word 2007+ document (document)
-eml/sample.eml: RFC 822 mail (text)
-empty/empty_file: Empty file (inode)
 ```
 
 ```shell

--- a/tests_data/basic/awk/weekly_totals.awk
+++ b/tests_data/basic/awk/weekly_totals.awk
@@ -1,0 +1,14 @@
+BEGIN {
+  FS = ","
+  print "region,total"
+}
+
+NR > 1 {
+  totals[$1] += $3
+}
+
+END {
+  for (region in totals) {
+    printf "%s,%.2f\n", region, totals[region]
+  }
+}

--- a/tests_data/basic/bib/references.bib
+++ b/tests_data/basic/bib/references.bib
@@ -1,0 +1,18 @@
+@article{rivera2025gardens,
+  author  = {Maya Rivera and Arun Mehta},
+  title   = {Measuring Pollinator Visits in Community Gardens},
+  journal = {Journal of Urban Ecology Studies},
+  year    = {2025},
+  volume  = {12},
+  number  = {3},
+  pages   = {44--61},
+  doi     = {10.5555/jues.2025.1203}
+}
+
+@book{chen2024fieldnotes,
+  author    = {Lin Chen},
+  title     = {Field Notes for Small Weather Stations},
+  publisher = {Northwind Press},
+  address   = {Portland},
+  year      = {2024}
+}

--- a/tests_data/basic/hcl/service.hcl
+++ b/tests_data/basic/hcl/service.hcl
@@ -1,0 +1,13 @@
+service "catalog" {
+  image = "registry.example.test/catalog:1.4"
+
+  resources {
+    cpu    = 2
+    memory = "512MiB"
+  }
+
+  environment = {
+    LOG_LEVEL = "info"
+    REGION    = "us-central1"
+  }
+}


### PR DESCRIPTION
## Summary

- add basic AWK, BibTeX, and HCL samples for content-type regression coverage
- keep each example small while including enough format-specific syntax for reliable identification

Contributes to #662.

## Sample provenance

I wrote all three text files from scratch for this pull request. The AWK program aggregates a fictional CSV report, the BibTeX entries use fictional authors and publications, and the HCL file describes a fictional service using the reserved `.test` domain. No third-party files or generated content are included.

## Testing

- `magika --json tests_data/basic/hcl/service.hcl tests_data/basic/awk/weekly_totals.awk tests_data/basic/bib/references.bib` — all three returned the expected labels with the `standard_v3_3` model
- `python/scripts/run_quick_test_magika_cli.py` — passed against the full basic corpus
- `python/scripts/run_quick_test_magika_module.py` — passed against the full basic corpus
- `go test ./...` (from `go/`) — passed

Local note: I initially ran `go test ./...` from the repository root, which is not a Go module; rerunning it from `go/` passed.
