### PR TITLE
test: add basic Lua, Erlang, and Fortran samples

### DIFF
--- a/tests_data/basic/erlang/weather_station.erl
+++ b/tests_data/basic/erlang/weather_station.erl
@@ -1,0 +1,12 @@
+-module(weather_station).
+-export([average/1, status/1]).
+
+average(Readings) when is_list(Readings), Readings =/= [] ->
+    lists:sum(Readings) / length(Readings).
+
+status(Temperature) when Temperature < 5 ->
+    cold;
+status(Temperature) when Temperature > 28 ->
+    hot;
+status(_Temperature) ->
+    mild.

--- a/tests_data/basic/fortran/temperature_report.f90
+++ b/tests_data/basic/fortran/temperature_report.f90
@@ -1,0 +1,10 @@
+program temperature_report
+  implicit none
+
+  real, dimension(4) :: readings = [18.5, 20.0, 21.5, 19.0]
+  real :: mean_temperature
+
+  mean_temperature = sum(readings) / size(readings)
+
+  print '(A, F5.1, A)', 'Average temperature: ', mean_temperature, ' C'
+end program temperature_report

--- a/tests_data/basic/lua/weather.lua
+++ b/tests_data/basic/lua/weather.lua
@@ -1,0 +1,16 @@
+local observations = {
+  { station = "north", temperature = 18.4 },
+  { station = "south", temperature = 21.7 },
+}
+
+local function describe(observation)
+  return string.format(
+    "%s station: %.1f C",
+    observation.station,
+    observation.temperature
+  )
+end
+
+for _, observation in ipairs(observations) do
+  print(describe(observation))
+end


### PR DESCRIPTION
## Summary

- add basic Lua, Erlang, and Fortran samples for content-type regression coverage
- keep each example small while including characteristic syntax for its language

Contributes to #662.

## Sample provenance

I wrote all three text files from scratch for this pull request. They use fictional weather readings and station names, and do not include any third-party or generated source material.

## Testing

- `magika --json tests_data/basic/lua/weather.lua tests_data/basic/erlang/weather_station.erl tests_data/basic/fortran/temperature_report.f90` — all three returned the expected labels with the `standard_v3_3` model
- `python/scripts/run_quick_test_magika_cli.py` — passed against the full basic corpus
- `python/scripts/run_quick_test_magika_module.py` — passed against the full basic corpus
- `go test ./...` (from `go/`) — passed
- `git diff --check` — passed

## AI assistance

I used OpenAI Codex to help identify unclaimed content types, draft the sample files, and run the repository checks. I reviewed the final files, verified their behavior locally, and will respond to review feedback myself.
