### PR TITLE
test: add basic Git metadata samples

### DIFF
--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -76,9 +76,9 @@ bib/references.bib: BibTeX (text)
 c/code.c: C source (code)
 css/code.css: CSS source (code)
 csv/magika_test.csv: CSV document (code)
+diff/weather-station.patch: Diff file (text)
 dockerfile/Dockerfile: Dockerfile (code)
 docx/doc.docx: Microsoft Word 2007+ document (document)
-docx/magika_test.docx: Microsoft Word 2007+ document (document)
 ```
 
 ```shell

--- a/tests_data/basic/diff/weather-station.patch
+++ b/tests_data/basic/diff/weather-station.patch
@@ -1,0 +1,20 @@
+diff --git a/config/stations.toml b/config/stations.toml
+index 03a42aa..73d968f 100644
+--- a/config/stations.toml
++++ b/config/stations.toml
+@@ -1,5 +1,6 @@
+ [[station]]
+ id = "harbor-north"
+-interval_seconds = 60
++interval_seconds = 30
++record_wind_gusts = true
+ sensors = ["temperature", "wind"]
+
+diff --git a/docs/operations.md b/docs/operations.md
+index 8eb32e1..f45ce32 100644
+--- a/docs/operations.md
++++ b/docs/operations.md
+@@ -8,3 +8,4 @@ Operators should verify the following before each shift:
+ - The station clock is synchronized.
+ - The rain gauge is clear of debris.
++- The wind sensor reports both average speed and gusts.

--- a/tests_data/basic/gitattributes/repository.gitattributes
+++ b/tests_data/basic/gitattributes/repository.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.png binary
+*.woff2 binary
+
+docs/** linguist-documentation
+fixtures/** linguist-generated
+vendor/** linguist-vendored

--- a/tests_data/basic/gitmodules/project.gitmodules
+++ b/tests_data/basic/gitmodules/project.gitmodules
@@ -1,0 +1,9 @@
+[submodule "vendor/sensor-protocol"]
+	path = vendor/sensor-protocol
+	url = https://example.com/weather/sensor-protocol.git
+	branch = stable
+
+[submodule "tools/report-renderer"]
+	path = tools/report-renderer
+	url = https://example.com/weather/report-renderer.git
+	shallow = true


### PR DESCRIPTION
Related to #662.

This adds three small, clear-cut examples to the basic test corpus:

- a unified diff for a fictional weather-station project
- a `.gitattributes` file with common text, binary, and Linguist attributes
- a `.gitmodules` file with two fictional submodule entries

All three samples are original examples written from scratch for this pull request; no external source material was copied. I used an AI coding assistant while preparing and validating the contribution.

Tests:

- `python/.venv/bin/magika --json tests_data/basic/diff/weather-station.patch tests_data/basic/gitattributes/repository.gitattributes tests_data/basic/gitmodules/project.gitmodules` (all classified correctly with `standard_v3_3`, scores 0.999-1.000)
- `python/.venv/bin/python python/scripts/run_quick_test_magika_module.py`
- `PATH="$PWD/python/.venv/bin:$PATH" python/.venv/bin/python python/scripts/run_quick_test_magika_cli.py --client-path python/.venv/bin/magika`
- `go test ./...` (from `go/`)
- `git diff --check`
