### PR TITLE
test: add basic Clojure, Dart, and Elixir samples

### DIFF
--- a/rust/cli/README.md
+++ b/rust/cli/README.md
@@ -74,11 +74,11 @@ awk/weekly_totals.awk: Awk (code)
 batch/simple.bat: DOS batch file (code)
 bib/references.bib: BibTeX (text)
 c/code.c: C source (code)
+clojure/weather_summary.clj: Clojure (code)
 css/code.css: CSS source (code)
 csv/magika_test.csv: CSV document (code)
+dart/inventory_report.dart: Dart source (code)
 diff/weather-station.patch: Diff file (text)
-dockerfile/Dockerfile: Dockerfile (code)
-docx/doc.docx: Microsoft Word 2007+ document (document)
 ```
 
 ```shell

--- a/tests_data/basic/clojure/weather_summary.clj
+++ b/tests_data/basic/clojure/weather_summary.clj
@@ -1,0 +1,54 @@
+(ns weather-summary.core
+  (:require [clojure.string :as str]))
+
+(defrecord Reading [station temperature-c humidity])
+
+(defn celsius->fahrenheit [temperature]
+  (+ (* temperature 9/5) 32))
+
+(defn average [values]
+  (if (seq values)
+    (/ (reduce + values) (count values))
+    0))
+
+(defn parse-reading [line]
+  (let [[station temperature humidity] (str/split line #",")]
+    (->Reading station
+               (Double/parseDouble temperature)
+               (Long/parseLong humidity))))
+
+(defn station-summary [[station readings]]
+  (let [temperatures (map :temperature-c readings)
+        humidities (map :humidity readings)
+        mean-c (average temperatures)]
+    {:station station
+     :samples (count readings)
+     :mean-celsius (double mean-c)
+     :mean-fahrenheit (double (celsius->fahrenheit mean-c))
+     :mean-humidity (double (average humidities))}))
+
+(defn summarize [lines]
+  (->> lines
+       (remove str/blank?)
+       (map parse-reading)
+       (group-by :station)
+       (map station-summary)
+       (sort-by :station)))
+
+(defn format-summary [{:keys [station samples mean-celsius mean-fahrenheit
+                              mean-humidity]}]
+  (format "%s: %d samples, %.1f C / %.1f F, %.0f%% humidity"
+          station samples mean-celsius mean-fahrenheit mean-humidity))
+
+(def sample-readings
+  ["Auckland,18.5,74"
+   "Wellington,16.0,79"
+   "Auckland,20.0,68"
+   "Wellington,17.5,72"])
+
+(defn -main [& _args]
+  (doseq [line (map format-summary (summarize sample-readings))]
+    (println line)))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (-main))

--- a/tests_data/basic/dart/inventory_report.dart
+++ b/tests_data/basic/dart/inventory_report.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+enum StockStatus { available, low, unavailable }
+
+class Product {
+  const Product({
+    required this.sku,
+    required this.name,
+    required this.quantity,
+    required this.reorderLevel,
+  });
+
+  final String sku;
+  final String name;
+  final int quantity;
+  final int reorderLevel;
+
+  factory Product.fromJson(Map<String, Object?> json) {
+    return Product(
+      sku: json['sku']! as String,
+      name: json['name']! as String,
+      quantity: json['quantity']! as int,
+      reorderLevel: json['reorderLevel']! as int,
+    );
+  }
+
+  StockStatus get status {
+    if (quantity == 0) return StockStatus.unavailable;
+    if (quantity <= reorderLevel) return StockStatus.low;
+    return StockStatus.available;
+  }
+}
+
+extension StockStatusLabel on StockStatus {
+  String get label => switch (this) {
+        StockStatus.available => 'available',
+        StockStatus.low => 'low stock',
+        StockStatus.unavailable => 'unavailable',
+      };
+}
+
+Iterable<Product> decodeProducts(String source) sync* {
+  final records = jsonDecode(source) as List<Object?>;
+  for (final record in records) {
+    yield Product.fromJson(record! as Map<String, Object?>);
+  }
+}
+
+Map<StockStatus, List<Product>> groupByStatus(Iterable<Product> products) {
+  final grouped = <StockStatus, List<Product>>{};
+  for (final product in products) {
+    grouped.putIfAbsent(product.status, () => <Product>[]).add(product);
+  }
+  return grouped;
+}
+
+void printReport(Map<StockStatus, List<Product>> grouped) {
+  for (final status in StockStatus.values) {
+    final products = grouped[status] ?? const <Product>[];
+    print('${status.label}: ${products.length}');
+    for (final product in products) {
+      print('  ${product.sku} ${product.name} (${product.quantity})');
+    }
+  }
+}
+
+Future<void> main() async {
+  const source = '''
+  [
+    {"sku":"TEA-01","name":"Breakfast tea","quantity":14,"reorderLevel":5},
+    {"sku":"MUG-02","name":"Ceramic mug","quantity":3,"reorderLevel":4},
+    {"sku":"TIN-03","name":"Tea tin","quantity":0,"reorderLevel":2}
+  ]
+  ''';
+
+  final products = decodeProducts(source).toList(growable: false);
+  printReport(groupByStatus(products));
+}

--- a/tests_data/basic/elixir/forecast.exs
+++ b/tests_data/basic/elixir/forecast.exs
@@ -1,0 +1,70 @@
+defmodule Forecast do
+  @moduledoc "Summarizes manually entered weather observations."
+
+  defstruct [:city, :temperature_c, :condition]
+
+  @type condition :: :sunny | :cloudy | :rain
+  @type t :: %__MODULE__{
+          city: String.t(),
+          temperature_c: number(),
+          condition: condition()
+        }
+
+  @spec new(String.t(), number(), condition()) :: t()
+  def new(city, temperature_c, condition)
+      when is_binary(city) and is_number(temperature_c) do
+    %__MODULE__{
+      city: city,
+      temperature_c: temperature_c,
+      condition: condition
+    }
+  end
+
+  @spec warm?(t()) :: boolean()
+  def warm?(%__MODULE__{temperature_c: temperature}), do: temperature >= 20
+
+  @spec label(t()) :: String.t()
+  def label(%__MODULE__{} = forecast) do
+    temperature = :erlang.float_to_binary(forecast.temperature_c / 1, decimals: 1)
+    "#{forecast.city}: #{temperature} C, #{forecast.condition}"
+  end
+end
+
+defmodule ForecastReport do
+  @spec warm_cities([Forecast.t()]) :: [String.t()]
+  def warm_cities(forecasts) do
+    forecasts
+    |> Enum.filter(&Forecast.warm?/1)
+    |> Enum.map(& &1.city)
+    |> Enum.sort()
+  end
+
+  @spec count_by_condition([Forecast.t()]) :: map()
+  def count_by_condition(forecasts) do
+    Enum.frequencies_by(forecasts, fn forecast -> forecast.condition end)
+  end
+
+  @spec print([Forecast.t()]) :: :ok
+  def print(forecasts) do
+    Enum.each(forecasts, fn forecast ->
+      IO.puts(Forecast.label(forecast))
+    end)
+
+    warm = warm_cities(forecasts) |> Enum.join(", ")
+    IO.puts("Warm cities: #{warm}")
+
+    count_by_condition(forecasts)
+    |> Enum.sort()
+    |> Enum.each(fn {condition, count} ->
+      IO.puts("#{condition}: #{count}")
+    end)
+  end
+end
+
+forecasts = [
+  Forecast.new("Auckland", 21.5, :sunny),
+  Forecast.new("Christchurch", 18.0, :cloudy),
+  Forecast.new("Wellington", 16.5, :rain)
+]
+
+ForecastReport.print(forecasts)


### PR DESCRIPTION
## Summary

Adds easy-to-recognize basic samples for three currently uncovered source-code types: Clojure, Dart, and Elixir.

Relates to #662.

## Sample origins

All three samples were manually authored for this pull request. No sample content was copied from an existing project or online resource.

| Sample | Origin |
| --- | --- |
| `tests_data/basic/clojure/weather_summary.clj` | Manually authored weather-summary example |
| `tests_data/basic/dart/inventory_report.dart` | Manually authored inventory-report example |
| `tests_data/basic/elixir/forecast.exs` | Manually authored forecast-report example |

## Validation

- Ran `uv run --project python python python/scripts/run_quick_test_magika_module.py`; all basic examples were predicted correctly with `standard_v3_3`
- Ran the Clojure sample with `clojure -M`
- Ran `git diff --cached --check` before committing
