### PR TITLE
go: free ONNX model path C string

### DIFF
--- a/go/onnx/onnx_runtime.go
+++ b/go/onnx/onnx_runtime.go
@@ -3,11 +3,13 @@
 package onnx
 
 // #cgo LDFLAGS: -lonnxruntime
+// #include <stdlib.h>
 // #include "onnx_runtime.h"
 import "C"
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 // NewOnnx returns an onnx that can perform inferences using an ONNX Runtime
@@ -18,7 +20,9 @@ func NewOnnx(modelPath string, sizeTarget int) (Onnx, error) {
 		api:        C.GetApiBase(),
 		sizeTarget: sizeTarget,
 	}
-	if err := C.CreateSession(ort.api, C.CString(modelPath), &ort.session, &ort.memory); err != nil {
+	cModelPath := C.CString(modelPath)
+	defer C.free(unsafe.Pointer(cModelPath))
+	if err := C.CreateSession(ort.api, cModelPath, &ort.session, &ort.memory); err != nil {
 		return nil, fmt.Errorf("create session: %v", C.GoString(C.GetErrorMessage(err)))
 	}
 	return ort, nil


### PR DESCRIPTION
## Summary

Keep the `C.CString` used for the ONNX model path in a local variable and release it after `CreateSession` returns. The deferred `C.free` covers both the successful and error paths.

This intentionally leaves the separately reported ONNX-owned environment, options, and status cleanup out of scope.

Fixes #1444

## Testing

Using Go 1.22.3 and ONNX Runtime 1.19.2 with the versions, linker flags, assets, and SHA-256 digest pinned by the repository:

- `go test ./...`
- `go vet ./...`
- `go vet -tags onnxruntime ./...`
- `go test -v -tags onnxruntime -ldflags="-linkmode=external -extldflags=-L/opt/onnxruntime/lib" ./...`
- `go build -tags onnxruntime -ldflags="-linkmode=external -extldflags=-L/opt/onnxruntime/lib" .` from `go/cli`