### PR TITLE
Revert part of rust/cli/test.sh to avoid workflow freeze

### DIFF
--- a/rust/cli/test.sh
+++ b/rust/cli/test.sh
@@ -39,7 +39,7 @@ info "Test against the test suites: $TEST_SUITES"
   done
 )
 
-# We rely below on the fact that we don't have permission to read `chmod 000` files.
+# We rely below on the fact that we don't have permission on /etc/shadow.
 [ $(id -u) -eq 0 ] && success "No more tests in Docker"
 
 info "Test exit code with at least one error"
@@ -53,11 +53,8 @@ test_error() {
     [ "$actual" = "$expected" ] || error "invalid output for magika $files"
   )
 }
-unreadable=$(mktemp)
-trap 'chmod u+rw "$unreadable"; rm -f "$unreadable"' EXIT
-chmod 000 "$unreadable"
-test_error "$unreadable" "\
-$unreadable: Permission denied (os error 13) (error)"
+[ "$(uname -s)" = Linux ] && test_error '/etc/shadow' "\
+/etc/shadow: Permission denied (os error 13) (error)"
 test_error 'non_existent src/main.rs' "\
 non_existent: No such file or directory (os error 2) (error)
 src/main.rs: Rust source (code)"
@@ -65,3 +62,5 @@ src/main.rs: Rust source (code)"
 info "Test exit code with broken pipe"
 magika -r ../../tests_data | head -n1 >/dev/null
 [ "${PIPESTATUS[0]}" -eq 0 ] || error "non-zero exit code with broken pipe"
+
+success "Exit shell"


### PR DESCRIPTION
This PR reverts a change from #1437 that may be the root cause of freezes observed in the workflow, for example https://github.com/google/magika/actions/runs/34452716536/job/102791908727.